### PR TITLE
fix(frontend): handle non-JSON responses in request() and downloadResume()

### DIFF
--- a/frontend/src/api/request.test.ts
+++ b/frontend/src/api/request.test.ts
@@ -9,6 +9,14 @@ function mockFetch(status: number, body: unknown) {
   } as Response);
 }
 
+function mockFetchNonJson(status: number) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+  } as unknown as Response);
+}
+
 beforeEach(() => {
   setAuthToken(null);
   setUnauthorizedHandler(null);
@@ -65,5 +73,13 @@ describe('request()', () => {
   it('throws error with message on other non-2xx', async () => {
     mockFetch(500, { code: 500, message: 'Internal server error', data: null });
     await expect(request('/api/test')).rejects.toThrow('Internal server error');
+  });
+
+  it('throws graceful error when response body is not JSON', async () => {
+    mockFetchNonJson(502);
+    const err = await request('/api/test').catch((e: unknown) => e as Error & { status?: number });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(502);
+    expect(err.message).toMatch(/HTTP 502/);
   });
 });

--- a/frontend/src/api/request.ts
+++ b/frontend/src/api/request.ts
@@ -32,7 +32,18 @@ export async function request<T>(
   }
 
   const response = await fetch(path, { ...init, headers });
-  const body = await response.json();
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (e) {
+    // Non-JSON response body (e.g. proxy 502 HTML error page)
+    const cause = e instanceof Error ? e.message : String(e);
+    const err: Error & { status?: number } = new Error(
+      `HTTP ${response.status}${cause ? ` (${cause})` : ''}`
+    );
+    err.status = response.status;
+    throw err;
+  }
 
   if (response.ok) {
     return body.data as T;

--- a/frontend/src/api/resumes.test.ts
+++ b/frontend/src/api/resumes.test.ts
@@ -29,6 +29,32 @@ describe('resumes API', () => {
     expect(result).toBe(mockBlob);
   });
 
+  it('downloadResume() throws error with status and body text on non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('Resume not found'),
+    } as unknown as Response);
+    const { downloadResume } = await import('./resumes');
+    const err = await downloadResume('abc-123').catch((e: unknown) => e as Error & { status?: number });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Resume not found');
+  });
+
+  it('downloadResume() falls back to generic message on empty error body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: () => Promise.resolve(''),
+    } as unknown as Response);
+    const { downloadResume } = await import('./resumes');
+    const err = await downloadResume('abc-123').catch((e: unknown) => e as Error & { status?: number });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(502);
+    expect(err.message).toBe('Download failed (502)');
+  });
+
   it('uploadResume() POSTs multipart and returns resume on success', async () => {
     const mockResume = { id: 'r1', fileName: 'cv.pdf', fileType: 'PDF', source: 'MANUAL', status: 'UPLOADED', uploadedAt: '2026-03-01T00:00:00Z' };
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({

--- a/frontend/src/api/resumes.ts
+++ b/frontend/src/api/resumes.ts
@@ -42,7 +42,14 @@ export async function downloadResume(id: string): Promise<Blob> {
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const response = await fetch(`/api/resumes/${id}/download`, { headers });
-  if (!response.ok) throw new Error('Download failed');
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    const err: Error & { status?: number } = new Error(
+      text || `Download failed (${response.status})`
+    );
+    err.status = response.status;
+    throw err;
+  }
   return response.blob();
 }
 


### PR DESCRIPTION
## Summary
- Wrap `response.json()` in try/catch in `request.ts` — prevents uncaught `SyntaxError` when server/proxy returns non-JSON (e.g. 502 Bad Gateway HTML page). Throws shaped `Error` with `status` property.
- Improve `downloadResume()` error messages — now captures HTTP status code and response body text instead of throwing generic `"Download failed"`.
- Add test for non-JSON response path (`request.test.ts`)
- Add two error-path tests for `downloadResume` (`resumes.test.ts`)

## Test Evidence
```
14 passed (2 test files: request.test.ts, resumes.test.ts)
56 passed (full suite, 14 files)
```

## Risks
- None — fix is purely additive error handling, no happy-path changes
- Backend assumption: always returns JSON envelope `{ code, message, data }` on non-2xx. Non-JSON only occurs on proxy errors (network layer), not application errors.

## Rollback Notes
- Revert `request.ts`: Remove try/catch around `response.json()`, revert to direct `await response.json()`
- Revert `resumes.ts`: Revert `downloadResume` to `throw new Error('Download failed')`
- Revert tests: Remove 3 new tests

## Reviewer Checklist
- [ ] `request.ts` try/catch correctly handles `SyntaxError` from `response.json()`
- [ ] Error shape `Error & { status?: number }` is consistent with existing error patterns
- [ ] `downloadResume` error message includes status and body text
- [ ] New tests cover the primary error paths
- [ ] Full suite passes (56 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)