### PR TITLE
fix(ci): pass OPENAI_API_KEY to VPS deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -62,6 +62,8 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
@@ -69,7 +71,9 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: OPENAI_API_KEY
           script: |
+            export OPENAI_API_KEY="$OPENAI_API_KEY"
             /opt/ai-hiring/scripts/deploy.sh dev ${{ github.sha }}
 
   e2e:
@@ -93,8 +97,9 @@ jobs:
         working-directory: e2e-tests
         run: npx playwright test --project=chromium
         env:
-          BASE_URL: https://dev.${{ secrets.DOMAIN }}
-          TEST_SECRET: ${{ secrets.TEST_SECRET }}
+          BASE_URL: http://${{ secrets.VPS_HOST }}:3001
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,6 +26,8 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     environment: production
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Deploy to Production
         uses: appleboy/ssh-action@v1
@@ -33,9 +35,11 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: OPENAI_API_KEY
           script: |
+            export OPENAI_API_KEY="$OPENAI_API_KEY"
             /opt/ai-hiring/scripts/deploy.sh prod ${{ inputs.version }}
       - name: Health check
         run: |
-          curl -sf https://${{ secrets.DOMAIN }}/api/actuator/health || exit 1
+          curl -sf http://${{ secrets.VPS_HOST }}:8080/actuator/health || exit 1
           echo "Production deployment successful"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -62,6 +62,8 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
@@ -69,5 +71,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: OPENAI_API_KEY
           script: |
+            export OPENAI_API_KEY="$OPENAI_API_KEY"
             /opt/ai-hiring/scripts/deploy.sh staging ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Add OPENAI_API_KEY environment variable to deploy jobs
- Use appleboy/ssh-action `envs` parameter to pass the API key to VPS
- Update E2E tests to use TEST_USERNAME/TEST_PASSWORD instead of TEST_SECRET
- Fix production health check URL (use IP-based URL for now)

## Test plan
- [ ] Merge to master triggers staging deployment
- [ ] Deployment receives OPENAI_API_KEY correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)