### PR TITLE
fix(e2e): add type module to e2e-tests package.json

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -2,6 +2,7 @@
   "name": "e2e-tests",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "playwright test",
     "test:ui": "playwright test --ui",


### PR DESCRIPTION
## Summary
Fix E2E test ESM compatibility issue by adding `"type": "module"` to `e2e-tests/package.json`.

## Changes
- Added `"type": "module"` to `e2e-tests/package.json`
- Regenerated `package-lock.json`

## Root Cause
E2E test files use ES module syntax (`import`, `import.meta.url`) but `package.json` lacked `"type": "module"`, causing Node to default to CJS mode and throw `ReferenceError: require is not defined`.

## Related Issues
Closes #28

## Test Plan
- [x] CI will run on this PR
- [x] Staging E2E tests should pass after merge

## Checklist
- [x] No breaking API changes
- [x] Followed architecture boundaries