### PR TITLE
fix(ci): use urllib.request for AI code review API call

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -35,7 +35,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           python3 << 'PYEOF'
-          import json, subprocess, os
+          import json, os, urllib.request, urllib.error
 
           with open("/tmp/pr-diff.txt", "r") as f:
               diff_content = f.read()
@@ -57,29 +57,34 @@ jobs:
               "If the diff looks fine, say 'LGTM' briefly."
           )
 
-          payload = {
+          payload = json.dumps({
               "model": "gpt-4o",
               "max_tokens": 4096,
               "messages": [
                   {"role": "system", "content": system_prompt},
-                  {"role": "user", "content": f"Review this PR diff:\n\n{diff_content}"}
+                  {"role": "user", "content": "Review this PR diff:\n\n" + diff_content}
               ]
-          }
+          }).encode("utf-8")
 
-          resp = subprocess.run(
-              ["curl", "-s", "https://api.openai.com/v1/chat/completions",
-               "-H", "Content-Type: application/json",
-               "-H", f"Authorization: Bearer {os.environ['OPENAI_API_KEY']}",
-               "-d", json.dumps(payload)],
-              capture_output=True, text=True
+          req = urllib.request.Request(
+              "https://api.openai.com/v1/chat/completions",
+              data=payload,
+              headers={
+                  "Content-Type": "application/json",
+                  "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"
+              }
           )
 
           try:
-              data = json.loads(resp.stdout)
+              with urllib.request.urlopen(req, timeout=60) as resp:
+                  data = json.loads(resp.read().decode("utf-8"))
               choices = data.get("choices", [])
               review_text = choices[0]["message"]["content"] if choices else "AI review returned no response."
-          except Exception:
-              review_text = "AI review failed to parse response."
+          except urllib.error.HTTPError as e:
+              body = e.read().decode("utf-8", errors="replace")
+              review_text = f"AI review API error (HTTP {e.code}): {body[:200]}"
+          except Exception as e:
+              review_text = f"AI review failed: {e}"
 
           with open("/tmp/review-comment.md", "w") as f:
               f.write(review_text)


### PR DESCRIPTION
## Summary
Fix AI Code Review returning empty responses by replacing `curl` subprocess call with Python's `urllib.request`.

## Root Cause
The previous approach used `subprocess.run(["curl", ..., "-d", json.dumps(payload)])` to call the OpenAI API. When diff content contains special characters, the large JSON string passed as a command-line argument gets corrupted, causing the API to return errors or empty responses.

## Changes
- Replace `curl` subprocess with Python `urllib.request.urlopen()`
- Write payload as bytes directly, avoiding command-line argument encoding issues
- Add proper `HTTPError` handling that surfaces API error messages

## Test Plan
- [x] YAML validates
- [ ] After merge, next PR should show actual AI review comments

## Checklist
- [x] No breaking API changes