### PR TITLE
fix(ci): fix prod deploy version save - $GITHUB_OUTPUT not in SSH

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     outputs:
-      previous_version: ${{ steps.save_version.outputs.previous }}
+      previous_version: ${{ steps.set_version.outputs.previous }}
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
@@ -40,9 +40,12 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          capture_stdout: true
           script: |
-            PREV=$(grep "IMAGE_TAG=" /opt/ai-hiring/docker/prod/.env 2>/dev/null | cut -d= -f2 || echo "unknown")
-            echo "previous=$PREV" >> $GITHUB_OUTPUT
+            grep "IMAGE_TAG=" /opt/ai-hiring/docker/prod/.env 2>/dev/null | cut -d= -f2 || echo "unknown"
+      - name: Set previous version output
+        id: set_version
+        run: echo "previous=${{ steps.save_version.outputs.stdout }}" >> "$GITHUB_OUTPUT"
       - name: Copy deploy scripts to VPS
         uses: appleboy/scp-action@v1
         with:


### PR DESCRIPTION
## Summary
- Fix "Save current version" step that failed because `$GITHUB_OUTPUT` doesn't exist in SSH sessions
- Use `capture_stdout: true` on ssh-action, then write output in a separate runner-local step

## Root cause
```
bash: line 2: $GITHUB_OUTPUT: ambiguous redirect
```
The previous code tried to write to `$GITHUB_OUTPUT` inside the remote SSH session where it doesn't exist.

## Test plan
- [ ] Merge and trigger manual production deploy
- [ ] Verify "Save current version" step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)