### PR TITLE
fix(ci): strip extra output from ssh-action stdout for prod version

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,7 +45,9 @@ jobs:
             grep "IMAGE_TAG=" /opt/ai-hiring/docker/prod/.env 2>/dev/null | cut -d= -f2 || echo "unknown"
       - name: Set previous version output
         id: set_version
-        run: echo "previous=${{ steps.save_version.outputs.stdout }}" >> "$GITHUB_OUTPUT"
+        run: |
+          PREV=$(echo "${{ steps.save_version.outputs.stdout }}" | head -1 | tr -d '[:space:]')
+          echo "previous=${PREV:-unknown}" >> "$GITHUB_OUTPUT"
       - name: Copy deploy scripts to VPS
         uses: appleboy/scp-action@v1
         with:


### PR DESCRIPTION
## Summary
- `appleboy/ssh-action` with `capture_stdout` includes banner lines (`✅ Successfully executed...`) in stdout
- Only the first line contains the actual version SHA
- Use `head -1 | tr -d '[:space:]'` to extract just the version

## Test plan
- [ ] Merge and trigger production deploy
- [ ] Verify "Set previous version output" step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)