### PR TITLE
fix(frontend): resolve JD creation submit not responding - closes #49

### DIFF
--- a/frontend/src/pages/jobs/JobCreatePage.tsx
+++ b/frontend/src/pages/jobs/JobCreatePage.tsx
@@ -46,12 +46,9 @@ export default function JobCreatePage() {
         <Form.Item name="departmentId" label="Department" rules={[{ required: true }]}>
           <Select
             placeholder="Select department"
-            onDropdownVisibleChange={setDropdownOpen}
-          >
-            {departments.map((d) => (
-              <Select.Option key={d.id} value={d.id}>{d.name}</Select.Option>
-            ))}
-          </Select>
+            onOpenChange={setDropdownOpen}
+            options={departments.map((d) => ({ value: d.id, label: d.name }))}
+          />
         </Form.Item>
         <Form.Item name="description" label="Description" rules={[{ required: true }]}>
           <Input.TextArea rows={4} placeholder="Description" />

--- a/frontend/src/pages/jobs/JobDetailPage.tsx
+++ b/frontend/src/pages/jobs/JobDetailPage.tsx
@@ -185,11 +185,9 @@ export default function JobDetailPage() {
             <Input />
           </Form.Item>
           <Form.Item name="departmentId" label="Department" rules={[{ required: true }]}>
-            <Select>
-              {departments.map((d) => (
-                <Select.Option key={d.id} value={d.id}>{d.name}</Select.Option>
-              ))}
-            </Select>
+            <Select
+              options={departments.map((d) => ({ value: d.id, label: d.name }))}
+            />
           </Form.Item>
           <Form.Item name="description" label="Description" rules={[{ required: true }]}>
             <Input.TextArea rows={4} />


### PR DESCRIPTION
## Summary

Fixes #49 — the Submit button on the Job Create page did nothing when clicked (no error, no success, no network request).

## Root Cause

In **Ant Design v6**, `Select.Option` is a no-op that renders `null` (the component function body is `() => null`). The project uses `antd@6.3.3`, but the department dropdown still used the deprecated `<Select.Option>` children pattern:

```tsx
// Renders nothing in antd v6
<Select>
  {departments.map((d) => (
    <Select.Option key={d.id} value={d.id}>{d.name}</Select.Option>
  ))}
</Select>
```

This meant the department dropdown showed **zero options**. The user could not select a department, so the `departmentId` required field remained empty. Ant Design form validation failed silently (no `onFinishFailed` handler), `onFinish` was never called, and the submit button appeared to do nothing.

The same broken pattern also existed in `JobDetailPage.tsx` (edit form department dropdown).

## Changes Made

1. **`frontend/src/pages/jobs/JobCreatePage.tsx`**: Replaced `Select.Option` children with the `options` prop on `Select`. Updated deprecated `onDropdownVisibleChange` to `onOpenChange`.
2. **`frontend/src/pages/jobs/JobDetailPage.tsx`**: Replaced `Select.Option` children with the `options` prop on `Select` in the edit form.

## Test Plan

- [x] All 66 existing frontend tests pass (including the 3 `JobCreatePage` tests that verify form submission)
- [x] TypeScript type checking passes (`tsc --noEmit` clean)
- [ ] Manual verification on target environment: fill out JD form, select department, click Submit, confirm job is created and page navigates to job detail

## Residual Risks

- Any other pages using `Select.Option` would have the same issue. A grep found only these two files were affected.
- The `onDropdownVisibleChange` deprecation is cosmetic; the sentinel span for tests still works via `onOpenChange`.

## Commands Run

```
cd frontend && npx vitest run   # 66/66 passed
cd frontend && npx tsc --noEmit # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)