### PR TITLE
fix: force re-sync role_permissions (issue #57)

### DIFF
--- a/ai-hiring-backend/src/main/resources/db/migration/V8__force_sync_role_permissions.sql
+++ b/ai-hiring-backend/src/main/resources/db/migration/V8__force_sync_role_permissions.sql
@@ -1,0 +1,45 @@
+-- V8__force_sync_role_permissions.sql
+-- Force re-sync role_permissions for SUPER_ADMIN.
+-- V7 used ON CONFLICT DO NOTHING which didn't fix the actual issue.
+-- This migration uses DELETE + re-INSERT to guarantee correctness.
+
+-- Step 1: Delete all existing role_permissions for SUPER_ADMIN
+DELETE FROM role_permissions
+WHERE role_id = (SELECT id FROM roles WHERE name = 'SUPER_ADMIN');
+
+-- Step 2: Re-insert ALL permissions for SUPER_ADMIN using actual DB IDs
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'SUPER_ADMIN';
+
+-- Step 3: Also fix HR_ADMIN, DEPT_ADMIN, USER roles
+DELETE FROM role_permissions
+WHERE role_id = (SELECT id FROM roles WHERE name = 'HR_ADMIN');
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'HR_ADMIN';
+
+DELETE FROM role_permissions
+WHERE role_id IN (SELECT id FROM roles WHERE name IN ('DEPT_ADMIN', 'USER'));
+
+-- DEPT_ADMIN: all except user:manage, department:manage, role:manage, role:read
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'DEPT_ADMIN'
+  AND p.name IN ('user:read', 'department:read', 'resume:read', 'resume:manage',
+                  'job:read', 'job:manage', 'match:read', 'match:execute');
+
+-- USER: read-only
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'USER'
+  AND p.name IN ('resume:read', 'job:read', 'match:read');


### PR DESCRIPTION
## Summary
V7 migration (`ON CONFLICT DO NOTHING`) was a no-op — permissions data already existed but was incorrect. This PR uses `DELETE + re-INSERT` approach with dynamic DB IDs (no hardcoded UUIDs).

## Root cause hypothesis
The `role_permissions` join table has entries mapping to wrong permission IDs, or SUPER_ADMIN is missing entries for `department:read`, `role:read`, `user:read`. This causes 403 on `/api/departments`, `/api/roles`, and prevents JD creation (needs departmentId).

## Staging evidence (after V7)
| Endpoint | Permission needed | Result |
|----------|-------------------|--------|
| `/api/jobs` | `job:read` | 200 |
| `/api/resumes` | `resume:read` | 200 |
| `/api/match` | `match:execute` | 400 (OK) |
| `/api/departments` | `department:read` | **403** |
| `/api/roles` | `role:read` | **403** |

## Fix
V8 migration:
1. `DELETE` all role_permissions for each role
2. `INSERT` using `CROSS JOIN` with actual DB IDs (`WHERE r.name = 'SUPER_ADMIN'`)
3. No hardcoded UUIDs — works regardless of how data was originally seeded

## Test plan
- [ ] Merge, wait for staging deploy
- [ ] Verify `/api/departments` returns 200
- [ ] Create a JD with department selected
- [ ] View JD detail page — no spinner

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)