### PR TITLE
debug: add auth diagnostic endpoints (issue #57)

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/auth/AuthController.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/auth/AuthController.java
@@ -2,10 +2,14 @@ package com.aihiring.auth;
 
 import com.aihiring.auth.dto.*;
 import com.aihiring.common.dto.ApiResponse;
+import com.aihiring.common.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -30,5 +34,16 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> logout(@Valid @RequestBody LogoutRequest request) {
         authService.logout(request);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> me(@AuthenticationPrincipal UserDetailsImpl user) {
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "id", user.getId(),
+                "username", user.getUsername(),
+                "roles", user.getRoles(),
+                "permissions", user.getPermissions(),
+                "departmentId", user.getDepartmentId() != null ? user.getDepartmentId().toString() : null
+        )));
     }
 }

--- a/ai-hiring-backend/src/main/java/com/aihiring/auth/AuthDebugController.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/auth/AuthDebugController.java
@@ -1,0 +1,54 @@
+package com.aihiring.auth;
+
+import com.aihiring.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Temporary debug controller to diagnose permission loading issues.
+ * Remove after issue #57 is resolved.
+ */
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthDebugController {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @GetMapping("/debug/permissions")
+    public ApiResponse<List<Map<String, Object>>> debugPermissions() {
+        // Show all permissions
+        List<Map<String, Object>> permissions = jdbcTemplate.queryForList("SELECT id, name FROM permissions ORDER BY name");
+
+        // Show SUPER_ADMIN role_permissions
+        List<Map<String, Object>> rolePerms = jdbcTemplate.queryForList("""
+            SELECT r.name as role_name, p.name as perm_name, p.id as perm_id
+            FROM role_permissions rp
+            JOIN roles r ON rp.role_id = r.id
+            JOIN permissions p ON rp.permission_id = p.id
+            WHERE r.name = 'SUPER_ADMIN'
+            ORDER BY p.name
+            """);
+
+        // Show role counts
+        List<Map<String, Object>> roleCounts = jdbcTemplate.queryForList("""
+            SELECT r.name as role_name, COUNT(rp.permission_id) as perm_count
+            FROM roles r
+            LEFT JOIN role_permissions rp ON r.id = rp.role_id
+            GROUP BY r.name
+            ORDER BY r.name
+            """);
+
+        return ApiResponse.success(List.of(
+                Map.of("section", "all_permissions", "data", permissions),
+                Map.of("section", "super_admin_permissions", "data", rolePerms),
+                Map.of("section", "role_permission_counts", "data", roleCounts)
+        ));
+    }
+}


### PR DESCRIPTION
## Purpose
Diagnostic PR to identify why `department:read`, `role:read`, `user:read` permissions are missing from SUPER_ADMIN authorities on staging, despite V7 and V8 migrations.

## Endpoints added
- **GET /api/auth/me** — returns current user's roles, permissions, departmentId (from SecurityContext)
- **GET /api/auth/debug/permissions** — raw JDBC query showing all permissions, SUPER_ADMIN role_permissions, and role permission counts

## Why
After V7 and V8 migrations, `/api/departments` still returns 403. We need to see:
1. What permissions the JwtAuthFilter actually loads into UserDetailsImpl
2. What the raw database role_permissions table contains

## Plan
1. Merge this PR
2. Call `/api/auth/debug/permissions` to see raw DB state
3. Call `/api/auth/me` with admin token to see loaded authorities
4. Identify the gap and fix in a follow-up PR
5. Remove debug endpoints before production

**This PR is temporary — debug endpoints will be removed.**

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)