### PR TITLE
fix: rewrite V9 migration with valid SQL and add Flyway repair (issue #57)

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/common/FlywayConfig.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/common/FlywayConfig.java
@@ -1,0 +1,18 @@
+package com.aihiring.common;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayMigrationStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}

--- a/ai-hiring-backend/src/main/resources/db/migration/V9__unify_seed_data_chinese_dept_names.sql
+++ b/ai-hiring-backend/src/main/resources/db/migration/V9__unify_seed_data_chinese_dept_names.sql
@@ -1,61 +1,64 @@
 -- V9__unify_seed_data_chinese_dept_names.sql
- --
--- =============================================
--- 组织架构部门
- 应该有初始数据:
- 使用中文名称,研发部'、人事部'。
-但你
- 否部门虽然 '人事部' 统一由总部下面管理，所以创建 JD 的时候
-部门下拉
-菜单会显示这些部门。
-总部下面应该也能有子部门（产品部、市场部等）。
-这样前端创建 JD 时才能选择部门。
+-- Unify seed data: fix role_permissions using dynamic IDs, rename departments to Chinese.
+-- This replaces DataInitializer.java with Flyway-only approach.
 
-但如果没有部门，系统会为空，
+-- Step 1: Re-sync all role_permissions using CROSS JOIN with actual DB IDs
+DELETE FROM role_permissions WHERE role_id IN (SELECT id FROM roles);
 
-departmentId` 为必填。
-`departmentId` (创建 JD 时 `departmentId` 从 departments WHERE name IN ('研发部', '人事部'))
- VALUES ('product', 'product部'),
-        ('market', '市场部'),
-        ('finance', '财务部');
+-- SUPER_ADMIN: all permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'SUPER_ADMIN';
 
- -- 如果 not exists, do nothing
+-- HR_ADMIN: all except role:manage
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'HR_ADMIN'
+  AND p.name IN ('user:read', 'user:manage', 'department:read', 'department:manage',
+                  'role:read', 'role:manage', 'resume:read', 'resume:manage',
+                  'job:read', 'job:manage', 'match:read', 'match:execute');
 
- -- ensure all role-permission mappings are correct
-使用 dynamic IDs
-        DELETE FROM role_permissions WHERE role_id IN (SELECT id from roles where name in ('SUPER_ADMIN'));
-        INSERT INTO role_permissions (role_id, permission_id)
-        SELECT r.id, p.id
- FROM roles r, CROSS JOIN permissions p
- WHERE r.name = 'SUPER_ADMIN';
+-- DEPT_ADMIN: same as HR_ADMIN minus role:manage, user:manage, department:manage
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'DEPT_ADMIN'
+  AND p.name IN ('user:read', 'department:read', 'resume:read', 'resume:manage',
+                  'job:read', 'job:manage', 'match:read', 'match:execute');
 
-        -- HR_ADMIN: all except role:manage
-        INSERT INTO role_permissions (role_id, permission_id)
-        SELECT r.id, p.id
- FROM roles r
- CROSS JOIN permissions p
- WHERE r.name = 'HR_ADMIN' AND p.name in ('user:read', 'user:manage', 'department:read', 'department:manage', 'role:read', 'role:manage',
- 'resume:read', 'resume:manage', 'job:read', 'job:manage', 'match:read', 'match:execute');
-        -- DEPT_ADMIN
- same as HR_ADMIN minus role:manage, all
-        INSERT INTO role_permissions (role_id, permission_id)
-        SELECT r.id, p.id
- FROM roles r
- CROSS JOIN permissions p
- where r.name = 'DEPT_ADMIN' AND p.name in ('user:read', 'department:read', 'resume:read', 'resume:manage', 'job:read', 'job:manage', 'match:read', 'match:execute');
-        -- USER: read-only
-        INSERT INTO role_permissions (role_id, permission_id)
-        SELECT r.id, p.id
- FROM roles r
- CROSS JOIN permissions p
- where r.name = 'USER' and p.name in ('resume:read', 'job:read', 'match:read');
-        -- Step 4: Update department names to Chinese
+-- USER: read-only
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'USER'
+  AND p.name IN ('resume:read', 'job:read', 'match:read');
+
+-- Step 2: Update department names to Chinese
 UPDATE departments SET name = '总部' WHERE name = 'Headquarters';
 UPDATE departments SET name = '研发部' WHERE name = 'Engineering';
 UPDATE departments SET name = '人事部' WHERE name = 'Human Resources';
-        -- Add missing departments
-        INSERT INTO departments (name, id, parent_id)
- VALUES
- ('产品部', hq_id), ('市场部', hq_id), ('财务部', hq_id);
-END CASE when not exists;
 
+-- Step 3: Add missing departments under HQ
+INSERT INTO departments (id, name, parent_id)
+SELECT '03000000-0000-0000-0000-000000000004', '产品部', d.id
+FROM departments d
+WHERE d.name = '总部'
+  AND NOT EXISTS (SELECT 1 FROM departments WHERE name = '产品部');
+
+INSERT INTO departments (id, name, parent_id)
+SELECT '03000000-0000-0000-0000-000000000005', '市场部', d.id
+FROM departments d
+WHERE d.name = '总部'
+  AND NOT EXISTS (SELECT 1 FROM departments WHERE name = '市场部');
+
+INSERT INTO departments (id, name, parent_id)
+SELECT '03000000-0000-0000-0000-000000000006', '财务部', d.id
+FROM departments d
+WHERE d.name = '总部'
+  AND NOT EXISTS (SELECT 1 FROM departments WHERE name = '财务部');


### PR DESCRIPTION
## Summary
- Rewrote `V9__unify_seed_data_chinese_dept_names.sql` with valid, idempotent SQL
- Added `FlywayConfig` bean to repair failed migrations before re-attempting
- Root cause: V9 contained garbled/invalid SQL that caused backend to crash on startup (never healthy within 360s)

## Root Cause
V9 migration was corrupted — contained malformed comments, undefined variables (`hq_id`), invalid `FROM` syntax (`FROM roles r, CROSS JOIN`), and dangling statements. Flyway failed to apply it, the backend couldn't start, and the health check timed out.

## Changes
1. **V9 rewrite**: Proper DELETE + CROSS JOIN INSERT for role_permissions, UPDATE for department names, conditional INSERT for new departments
2. **FlywayConfig**: `repair()` before `migrate()` so failed V9 gets retried with fixed SQL

## Test plan
- [ ] Backend starts successfully on staging
- [ ] `/api/departments` returns departments with Chinese names
- [ ] `/api/roles` returns 200 (permissions properly mapped)
- [ ] `/api/jobs` and `/api/jobs/{id}` return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)