### PR TITLE
fix: E2E login reliability and strict mode selector

### DIFF
--- a/e2e-tests/tests/core-flows.spec.ts
+++ b/e2e-tests/tests/core-flows.spec.ts
@@ -9,17 +9,21 @@ const TS = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
 async function login(page: Page) {
   for (let attempt = 0; attempt < 3; attempt++) {
     await page.goto('/login');
+    await expect(page.getByPlaceholder('Username')).toBeVisible({ timeout: 5000 });
     await page.getByPlaceholder('Username').fill(process.env.TEST_USERNAME || 'admin');
     await page.getByPlaceholder('Password').fill(process.env.TEST_PASSWORD || 'admin123');
     await page.getByRole('button', { name: /login/i }).click();
     try {
-      await expect(page).toHaveURL(/.*\/(jobs|resumes)/, { timeout: 10000 });
+      await page.waitForURL(/.*\/(jobs|resumes|dashboard)/, { timeout: 15000 });
+      // Verify we actually left the login page
+      await expect(page.getByPlaceholder('Username')).not.toBeVisible({ timeout: 3000 });
       return; // success
     } catch {
-      if (attempt < 2) await page.waitForTimeout(1000); // retry on server error
+      if (attempt < 2) await page.waitForTimeout(2000);
     }
   }
-  throw new Error('Login failed after 3 attempts');
+  const url = page.url();
+  throw new Error(`Login failed after 3 attempts. Current URL: ${url}`);
 }
 
 test.describe.serial('Core flows', () => {
@@ -146,7 +150,7 @@ test.describe('Page rendering', () => {
   test('resume list page renders', async ({ page }) => {
     await login(page);
     await page.goto('/resumes');
-    await expect(page.getByRole('button', { name: /upload/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Upload Resume' })).toBeVisible({ timeout: 10000 });
   });
 });
 


### PR DESCRIPTION
## Summary
- **Login flakiness**: Tests were silently failing to log in — the `login()` helper didn't wait for the login form to render before filling it, and used a 10s timeout that was too short for staging. Now waits for form visibility, uses 15s timeout, and verifies we actually left the login page.
- **Strict mode violation**: `getByRole('button', { name: /upload/i })` matched both "Upload Resume" and "Batch Upload" buttons. Changed to exact name `'Upload Resume'`.

## Root cause evidence
CI screenshots showed login page still visible after `login()` returned — the URL check was passing but the page hadn't actually transitioned. Page snapshot for resume test showed: `strict mode violation: resolved to 2 elements`.

## Test plan
- [ ] CI passes
- [ ] Staging deploy succeeds
- [ ] All E2E tests pass (especially: create JD, job list renders, resume list renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)