### PR TITLE
fix: flaky JobDetailPage spinner test

### DIFF
--- a/frontend/src/pages/jobs/JobDetailPage.real.test.tsx
+++ b/frontend/src/pages/jobs/JobDetailPage.real.test.tsx
@@ -81,12 +81,11 @@ describe('JobDetailPage with REAL backend response', () => {
 
   it('should NOT be stuck on loading spinner', async () => {
     renderDetailPage();
-    // Wait for the page to finish loading
+    // Wait for the title to appear (proves loading completed)
     await waitFor(() => {
-      // The spinner should be gone
-      expect(screen.queryByRole('img', { name: /loading/i })).not.toBeInTheDocument();
+      expect(screen.getByText('Backend Engineer')).toBeInTheDocument();
     }, { timeout: 5000 });
-    // The title should be visible
-    expect(screen.getByText('Backend Engineer')).toBeInTheDocument();
+    // The spinner should be gone once content is loaded
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- `JobDetailPage.real.test.tsx` test "should NOT be stuck on loading spinner" was flaky
- Root cause: `queryByRole('img', { name: /loading/ })` doesn't match Ant Design's `div.ant-spin` spinner, so `waitFor` passed immediately before data loaded, then `getByText('Backend Engineer')` failed
- Fix: wait for title to appear first (proves loading completed), then assert spinner is gone

## Test plan
- [ ] CI passes (this was the failing test)
- [ ] Deploy Staging succeeds + E2E passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)