### PR TITLE
fix: 创建JD失败

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/job/JobDescription.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/job/JobDescription.java
@@ -7,9 +7,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcType;
-import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.PostgreSQLEnumJdbcType;
-import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "job_descriptions")
@@ -26,8 +24,7 @@ public class JobDescription extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String requirements;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(columnDefinition = "jsonb")
+    @Column(columnDefinition = "TEXT")
     private String skills;
 
     @Column(length = 50)

--- a/ai-hiring-backend/src/main/resources/db/migration/V11__change_skills_column_to_text.sql
+++ b/ai-hiring-backend/src/main/resources/db/migration/V11__change_skills_column_to_text.sql
@@ -1,0 +1,4 @@
+-- The skills column was defined as JSONB but the application treats it as a plain
+-- comma-separated string.  Inserting a non-JSON string into a JSONB column causes
+-- a PostgreSQL error, which makes JD creation fail (issue #94).
+ALTER TABLE job_descriptions ALTER COLUMN skills TYPE TEXT USING skills::TEXT;

--- a/ai-hiring-backend/src/test/java/com/aihiring/job/JobServiceTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/job/JobServiceTest.java
@@ -92,6 +92,30 @@ class JobServiceTest {
     }
 
     @Test
+    void create_withSkills_shouldStoreSkillsAsPlainText() {
+        Department dept = createDepartment();
+        User user = createUser();
+        CreateJobRequest request = new CreateJobRequest();
+        request.setTitle("Backend Developer");
+        request.setDescription("Looking for a backend developer");
+        request.setSkills("Java, Python, SQL");
+        request.setDepartmentId(dept.getId());
+
+        when(departmentRepository.findById(dept.getId())).thenReturn(Optional.of(dept));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(jobRepository.save(any(JobDescription.class))).thenAnswer(i -> {
+            JobDescription j = i.getArgument(0);
+            j.setId(UUID.randomUUID());
+            return j;
+        });
+
+        JobDescription result = jobService.create(request, user.getId());
+
+        assertEquals("Java, Python, SQL", result.getSkills());
+        verify(jobRepository).save(any(JobDescription.class));
+    }
+
+    @Test
     void create_withNonExistentDepartment_shouldThrowResourceNotFoundException() {
         UUID deptId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();

--- a/frontend/src/pages/jobs/JobCreatePage.test.tsx
+++ b/frontend/src/pages/jobs/JobCreatePage.test.tsx
@@ -75,7 +75,7 @@ describe('JobCreatePage', () => {
     await waitFor(() => expect(screen.getByText('Title is required')).toBeInTheDocument());
   });
 
-  it('stays on form when createJob throws a generic error', async () => {
+  it('shows error message and stays on form when createJob throws a generic error', async () => {
     vi.mocked(jobsApi.createJob).mockRejectedValueOnce(new Error('Internal Server Error'));
 
     render(<MemoryRouter><JobCreatePage /></MemoryRouter>);
@@ -88,6 +88,7 @@ describe('JobCreatePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
     await waitFor(() => expect(jobsApi.createJob).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('Internal Server Error')).toBeInTheDocument());
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/jobs/JobCreatePage.tsx
+++ b/frontend/src/pages/jobs/JobCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Form, Input, Select, Button } from 'antd';
+import { Form, Input, Select, Button, message } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { createJob, type CreateJobRequest } from '../../api/jobs';
 import { listDepartments, type Department } from '../../api/departments';
@@ -26,6 +26,8 @@ export default function JobCreatePage() {
         form.setFields(
           Object.entries(fieldErrors).map(([name, errors]) => ({ name, errors: [errors] }))
         );
+      } else {
+        message.error(e instanceof Error ? e.message : 'Failed to create job');
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #94: 创建JD失败

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/94

## Changes

- fix: change skills column from JSONB to TEXT to fix JD creation failure

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #94
issue: #94