### PR TITLE
fix: widen education/experience columns to fix JD creation (#96)

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/job/JobDescription.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/job/JobDescription.java
@@ -27,10 +27,10 @@ public class JobDescription extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String skills;
 
-    @Column(length = 50)
+    @Column(columnDefinition = "TEXT")
     private String education;
 
-    @Column(length = 50)
+    @Column(columnDefinition = "TEXT")
     private String experience;
 
     @Column(name = "salary_range", length = 100)

--- a/ai-hiring-backend/src/main/resources/db/migration/V12__widen_job_description_columns.sql
+++ b/ai-hiring-backend/src/main/resources/db/migration/V12__widen_job_description_columns.sql
@@ -1,0 +1,5 @@
+-- Widen education and experience columns from VARCHAR(50) to TEXT.
+-- These are free-form text fields where users commonly enter descriptions
+-- longer than 50 characters (e.g. "Bachelor's degree or above in Computer Science").
+ALTER TABLE job_descriptions ALTER COLUMN education TYPE TEXT;
+ALTER TABLE job_descriptions ALTER COLUMN experience TYPE TEXT;


### PR DESCRIPTION
## Summary
- Widened `education` and `experience` columns in `job_descriptions` table from `VARCHAR(50)` to `TEXT`
- Updated JPA entity annotations to match (`@Column(columnDefinition = "TEXT")`)
- Added Flyway migration `V12__widen_job_description_columns.sql`

## Root Cause
Job creation returned HTTP 500 (`value too long for type character varying(50)`) when users entered education or experience values longer than 50 characters. These are free-form text fields where values like "Bachelor's degree or above in Computer Science or related field" (62 chars) are common.

## Verification (staging, localhost:8082, admin account)
- **Before fix**: `POST /api/jobs` with education > 50 chars → HTTP 500
- **After fix**: `POST /api/jobs` with education = "Bachelors degree or above in Computer Science or related field" (62 chars) → HTTP 200, job created successfully
- **DB verified**: Row stored correctly with full-length values

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)