### PR TITLE
fix: add nginx client_max_body_size for batch resume upload

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,5 +13,6 @@ server {
         proxy_pass http://backend:8080/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        client_max_body_size 220m;
     }
 }


### PR DESCRIPTION
## Summary
- **Root cause**: Nginx defaults to 1MB `client_max_body_size`, causing `413 Request Entity Too Large` for any batch resume upload exceeding 1MB total through the frontend proxy. This is why the backend worked fine via curl (direct port 8082) but failed from the UI (through nginx on port 3002).
- PR #99 correctly fixed the Spring `max-request-size` and status detection, but missed the nginx layer which sits in front of the backend.
- Added `client_max_body_size 220m` to the `/api/` location block in `frontend/nginx.conf`.

## Verification

1. **Before fix**: `curl -F "files=@600KB_file" -F "files=@600KB_file" http://localhost:3002/api/resumes/upload` → **413** (nginx HTML error)
2. **After fix**: Same request → **200** with `{"total":2,"succeeded":2,"failed":0,...}`
3. All 75 frontend tests pass (17 test files)

## Test plan
- [ ] Rebuild and redeploy staging frontend image
- [ ] Upload 2+ resume files (total > 1MB) via the Batch Upload modal on http://localhost:3002
- [ ] Verify upload succeeds and files appear in the resume list

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)