### PR TITLE
fix: add jti claim to prevent refresh token hash collisions

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/common/security/JwtTokenProvider.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/common/security/JwtTokenProvider.java
@@ -47,6 +47,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(userId.toString())
+                .id(UUID.randomUUID().toString())
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(key)


### PR DESCRIPTION
## Summary
- Adds a random UUID `jti` (JWT ID) claim to `generateRefreshToken()` in `JwtTokenProvider.java`
- Prevents identical SHA-256 hashes when the same user generates multiple refresh tokens within the same second
- Root cause of batch upload failures on staging: UNIQUE constraint violation on `refresh_tokens_token_hash_key` kicked users to login page

## Root Cause
`generateRefreshToken()` only used `subject` (userId) + `issuedAt` (second-precision) + `expiration` as JWT claims. When the same user logged in multiple times within one second, identical JWTs were produced, resulting in identical SHA-256 hashes and a `refresh_tokens_token_hash_key` UNIQUE constraint violation. This caused login/refresh to fail, kicking users to the login page.

## Changes Made
- **`JwtTokenProvider.java`**: Added `.id(UUID.randomUUID().toString())` to the refresh token builder (one-line change)
- `java.util.UUID` was already imported

## Verification
- All unit tests pass (`./gradlew test` -- BUILD SUCCESSFUL)
- Staging DB cleanup needed after merge: `DELETE FROM refresh_tokens WHERE revoked = true OR expires_at < NOW();`

## Staging Deployment Note
After merge, clean stale tokens and redeploy backend on staging.

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)