### PR TITLE
fix: resolve 403 on Match API by switching to @EntityGraph for permission loading

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/user/UserRepository.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/user/UserRepository.java
@@ -1,5 +1,6 @@
 package com.aihiring.user;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,6 +15,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
 
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.roles r LEFT JOIN FETCH r.permissions LEFT JOIN FETCH u.department WHERE u.id = :id")
+    @EntityGraph(attributePaths = {"roles", "roles.permissions", "department"})
+    @Query("SELECT u FROM User u WHERE u.id = :id")
     Optional<User> findByIdWithRolesAndPermissions(UUID id);
 }

--- a/ai-hiring-backend/src/test/java/com/aihiring/auth/AuthMeIntegrationTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/auth/AuthMeIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.aihiring.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test that exercises the full JWT auth flow:
+ * login -> get token -> call /api/auth/me -> verify roles and permissions are populated.
+ *
+ * This catches issues where JwtAuthFilter fails to load roles/permissions from the DB
+ * (e.g., due to Hibernate lazy-loading issues with open-in-view=false).
+ *
+ * Regression test for issue #103.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthMeIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void me_afterLogin_shouldReturnRolesAndPermissions() throws Exception {
+        // Step 1: Login to get a real JWT token
+        String loginBody = """
+            {"username": "admin", "password": "admin123"}
+            """;
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(loginBody))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+            .andReturn();
+
+        // Extract access token
+        String responseBody = loginResult.getResponse().getContentAsString();
+        Map<String, Object> response = objectMapper.readValue(responseBody, Map.class);
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        String accessToken = (String) data.get("accessToken");
+
+        // Step 2: Call /api/auth/me with the JWT token
+        // This exercises the full JwtAuthFilter -> findByIdWithRolesAndPermissions -> UserDetailsImpl path
+        mockMvc.perform(get("/api/auth/me")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.username").value("admin"))
+            .andExpect(jsonPath("$.data.roles").isArray())
+            .andExpect(jsonPath("$.data.roles", hasSize(greaterThanOrEqualTo(1))))
+            .andExpect(jsonPath("$.data.roles", hasItem("SUPER_ADMIN")))
+            .andExpect(jsonPath("$.data.permissions").isArray())
+            .andExpect(jsonPath("$.data.permissions", hasSize(greaterThanOrEqualTo(1))))
+            .andExpect(jsonPath("$.data.permissions", hasItem("job:read")));
+    }
+
+    @Test
+    void matchEndpoint_afterLogin_adminShouldNotGet403() throws Exception {
+        // Login as admin
+        String loginBody = """
+            {"username": "admin", "password": "admin123"}
+            """;
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(loginBody))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String responseBody = loginResult.getResponse().getContentAsString();
+        Map<String, Object> response = objectMapper.readValue(responseBody, Map.class);
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        String accessToken = (String) data.get("accessToken");
+
+        // Call /api/match - should NOT get 403
+        // (it may get a different error since there's no AI matching service running,
+        //  but 403 specifically means the permissions were not loaded)
+        mockMvc.perform(post("/api/match")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jobId\": \"00000000-0000-0000-0000-000000000001\", \"topK\": 5}"))
+            .andExpect(status().is(not(403)));
+    }
+}


### PR DESCRIPTION
## Summary
- **Issue 1 (403 on /api/match):** Replaced nested `LEFT JOIN FETCH` in `findByIdWithRolesAndPermissions` with `@EntityGraph(attributePaths = {"roles", "roles.permissions", "department"})`. The nested JOIN FETCH approach in Hibernate 6 with `open-in-view: false` can fail to properly initialize nested collections, causing `JwtAuthFilter` to create `UserDetailsImpl` with empty roles and permissions. This results in 403 on all permission-gated endpoints.
- **Issue 2 (AI Matching connection refused):** Already fixed in master via PR #104 (corrected `AI_MATCHING_URL` to `AI_MATCHING_BASE_URL` in staging docker-compose).
- Added integration test `AuthMeIntegrationTest` that exercises the full JWT flow: login -> get token -> call `/api/auth/me` -> verify roles and permissions are populated. Also tests that admin can access `/api/match` without getting 403.

## Root cause
`UserRepository.findByIdWithRolesAndPermissions()` used a JPQL query with nested `LEFT JOIN FETCH u.roles r LEFT JOIN FETCH r.permissions`. In Hibernate 6.5 (Spring Boot 3.3) with `open-in-view: false`, this can fail to properly initialize the nested `permissions` collection on the `Role` entity, especially when the Hibernate session closes immediately after the repository call (as in `JwtAuthFilter`, which runs outside any `@Transactional` boundary). Switching to `@EntityGraph` delegates the fetch strategy to Hibernate's entity graph mechanism, which handles nested collection loading more reliably.

## Changes
- `UserRepository.java`: Replace `@Query` with nested JOIN FETCH with `@EntityGraph(attributePaths)` + simple `@Query`
- `AuthMeIntegrationTest.java`: New integration test for full JWT auth flow with permission verification

## Test plan
- [x] `AuthMeIntegrationTest.me_afterLogin_shouldReturnRolesAndPermissions` passes
- [x] `AuthMeIntegrationTest.matchEndpoint_afterLogin_adminShouldNotGet403` passes
- [x] Full backend test suite passes (`./gradlew test`)
- [x] Docker-compose consistency tests pass (`pytest tests/test_docker_compose_consistency.py`)
- [ ] Verify on staging after deploy: login as admin, call `/api/auth/me`, confirm roles/permissions are non-empty
- [ ] Verify on staging: call `/api/match` as admin, confirm no 403

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)