### PR TITLE
fix: persist OPENAI_API_KEY to .env in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,15 +34,13 @@ if [ -n "$GHCR_TOKEN" ]; then
     echo "$GHCR_TOKEN" | docker login ghcr.io -u yukunchen --password-stdin
 fi
 
-# Persist runtime secrets to .env so docker compose picks them up
-if [ -n "$OPENAI_API_KEY" ]; then
-    if grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then
-        sed -i "s|^OPENAI_API_KEY=.*|OPENAI_API_KEY=$OPENAI_API_KEY|" .env
-    else
-        echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
-    fi
-    echo "🔑 OPENAI_API_KEY written to .env"
+# Validate required secrets from environment
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo "⚠️  OPENAI_API_KEY not set in environment — AI matching will not work"
 fi
+
+# Export so docker compose substitutes ${OPENAI_API_KEY} in .env
+export OPENAI_API_KEY
 
 # Pull latest images
 echo "📥 Pulling latest images..."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,6 +34,16 @@ if [ -n "$GHCR_TOKEN" ]; then
     echo "$GHCR_TOKEN" | docker login ghcr.io -u yukunchen --password-stdin
 fi
 
+# Persist runtime secrets to .env so docker compose picks them up
+if [ -n "$OPENAI_API_KEY" ]; then
+    if grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then
+        sed -i "s|^OPENAI_API_KEY=.*|OPENAI_API_KEY=$OPENAI_API_KEY|" .env
+    else
+        echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
+    fi
+    echo "🔑 OPENAI_API_KEY written to .env"
+fi
+
 # Pull latest images
 echo "📥 Pulling latest images..."
 docker compose pull


### PR DESCRIPTION
## Summary
- `deploy.sh` now writes `OPENAI_API_KEY` from the SSH session environment to `.env` before `docker compose up`
- Previously the key was passed via `appleboy/ssh-action` `envs` but never persisted — after the SSH session ended, the key was lost and AI matching service started with an empty key
- This fixes the AI matching "401 - no API key" error on staging

## Test plan
- [ ] CI passes
- [ ] After merge + deploy, verify AI matching service has the key: `docker exec staging-ai-matching-1 env | grep OPENAI`
- [ ] Match API returns results (not 503 or 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)