### PR TITLE
fix: use env_file for OPENAI_API_KEY to survive container restarts

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -33,12 +33,13 @@ services:
       - ai-hiring-network
   ai-matching:
     image: ${REGISTRY}/${IMAGE_PREFIX}/ai-matching-service:${IMAGE_TAG}
+    env_file:
+      - /opt/ai-hiring/secrets/dev.env
     ports:
       - "${AI_PORT}:8001"
     environment:
       - LLM_MODEL=gpt-4o-mini
       - EMBEDDING_MODEL=text-embedding-3-small
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - QDRANT_HOST=${QDRANT_HOST}
       - QDRANT_PORT=${QDRANT_PORT}
     restart: unless-stopped

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -35,12 +35,13 @@ services:
 
   ai-matching:
     image: ${REGISTRY}/${IMAGE_PREFIX}/ai-matching-service:${IMAGE_TAG}
+    env_file:
+      - /opt/ai-hiring/secrets/prod.env
     ports:
       - "${AI_PORT}:8001"
     environment:
       - LLM_MODEL=gpt-4o
       - EMBEDDING_MODEL=text-embedding-3-small
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - QDRANT_HOST=${QDRANT_HOST}
       - QDRANT_PORT=${QDRANT_PORT}
     restart: always

--- a/docker/staging/docker-compose.yml
+++ b/docker/staging/docker-compose.yml
@@ -32,12 +32,13 @@ services:
       - ai-hiring-network
   ai-matching:
     image: ${REGISTRY}/${IMAGE_PREFIX}/ai-matching-service:${IMAGE_TAG}
+    env_file:
+      - /opt/ai-hiring/secrets/staging.env
     ports:
       - "${AI_PORT}:8001"
     environment:
       - LLM_MODEL=gpt-4o-mini
       - EMBEDDING_MODEL=text-embedding-3-small
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - QDRANT_HOST=${QDRANT_HOST}
       - QDRANT_PORT=${QDRANT_PORT}
     restart: unless-stopped

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,13 +34,20 @@ if [ -n "$GHCR_TOKEN" ]; then
     echo "$GHCR_TOKEN" | docker login ghcr.io -u yukunchen --password-stdin
 fi
 
-# Validate required secrets from environment
-if [ -z "$OPENAI_API_KEY" ]; then
-    echo "⚠️  OPENAI_API_KEY not set in environment — AI matching will not work"
+# Write runtime secrets to a mode-600 env file so containers survive restarts
+# outside the deploy workflow (auto-restart, OOM, host reboot, manual restart).
+# GitHub secret is the source of truth; this file gets rewritten on every deploy.
+SECRETS_DIR="/opt/ai-hiring/secrets"
+SECRETS_FILE="$SECRETS_DIR/$ENV.env"
+if [ -n "$OPENAI_API_KEY" ]; then
+    sudo mkdir -p "$SECRETS_DIR"
+    sudo chmod 700 "$SECRETS_DIR"
+    echo "OPENAI_API_KEY=$OPENAI_API_KEY" | sudo tee "$SECRETS_FILE" > /dev/null
+    sudo chmod 600 "$SECRETS_FILE"
+    echo "🔑 Secrets written to $SECRETS_FILE (mode 600)"
+elif [ ! -f "$SECRETS_FILE" ]; then
+    echo "⚠️  OPENAI_API_KEY not in env and $SECRETS_FILE missing — AI matching will fail"
 fi
-
-# Export so docker compose substitutes ${OPENAI_API_KEY} in .env
-export OPENAI_API_KEY
 
 # Pull latest images
 echo "📥 Pulling latest images..."


### PR DESCRIPTION
## Problem
The previous pattern `OPENAI_API_KEY=${OPENAI_API_KEY}` in docker-compose only worked during the GitHub Actions deploy session. If a container was recreated outside that session (auto-restart, OOM, host reboot, manual `docker compose up`), the shell had no `OPENAI_API_KEY` and the container started with an empty key. AI matching calls then failed with OpenAI `401 - no API key`.

This was observed on staging: ai-matching container was recreated ~20 min after deploy, at which point match API started returning 500.

## Fix
Each env's `docker-compose.yml` now references a mode-600 secrets file:
```yaml
ai-matching:
  env_file:
    - /opt/ai-hiring/secrets/staging.env   # or dev.env / prod.env
```

`deploy.sh` writes `OPENAI_API_KEY` (from SSH env, sourced from GitHub secret) to that file on every deploy. Containers load from `env_file` on every start regardless of who restarted them.

## Properties
- GitHub secret stays the source of truth
- Secrets file is `mode 600`, owned by root, never committed
- Key rotations propagate on next deploy
- Survives container recreation outside the deploy workflow

## Verified on staging
- Wrote current key to `/opt/ai-hiring/secrets/staging.env`
- Updated VPS docker-compose.yml to use `env_file`
- `unset OPENAI_API_KEY && docker compose up -d --force-recreate ai-matching`
- Container loaded key from file; match API returns 200 with 10 matching resumes + LLM scores + reasoning

## Test plan
- [ ] CI passes
- [ ] Staging deploy succeeds (deploy.sh writes file, containers start cleanly)
- [ ] Post-deploy: `docker exec staging-ai-matching-1 printenv OPENAI_API_KEY` is non-empty
- [ ] Match API returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)