### PR TITLE
fix: chown secrets file so docker compose can read it

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,8 +41,10 @@ SECRETS_DIR="/opt/ai-hiring/secrets"
 SECRETS_FILE="$SECRETS_DIR/$ENV.env"
 if [ -n "$OPENAI_API_KEY" ]; then
     sudo mkdir -p "$SECRETS_DIR"
+    sudo chown "$(id -u):$(id -g)" "$SECRETS_DIR"
     sudo chmod 700 "$SECRETS_DIR"
     echo "OPENAI_API_KEY=$OPENAI_API_KEY" | sudo tee "$SECRETS_FILE" > /dev/null
+    sudo chown "$(id -u):$(id -g)" "$SECRETS_FILE"
     sudo chmod 600 "$SECRETS_FILE"
     echo "🔑 Secrets written to $SECRETS_FILE (mode 600)"
 elif [ ! -f "$SECRETS_FILE" ]; then


### PR DESCRIPTION
## Summary
- `/opt/ai-hiring/secrets/<env>.env` was created as root:root mode 600 via `sudo tee`
- docker compose runs as VPS_USER and failed to read the file for the `env_file` directive
- Fix: chown the dir and file to the deploy user after writing

## Test plan
- [ ] Merge → staging deploy workflow runs
- [ ] Deploy completes without "permission denied"
- [ ] `ai-matching` container starts with OPENAI_API_KEY available
- [ ] Staging frontend reachable on port 3002

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)