### PR TITLE
fix: lazily vectorize JD on match when not indexed (#110)

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/matching/MatchService.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/matching/MatchService.java
@@ -1,18 +1,39 @@
 package com.aihiring.matching;
 
+import com.aihiring.common.exception.ResourceNotFoundException;
+import com.aihiring.job.JobDescription;
+import com.aihiring.job.JobRepository;
 import com.aihiring.matching.dto.AiMatchResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MatchService {
 
     private final AiMatchingClient client;
+    private final JobRepository jobRepository;
 
     public AiMatchResponse match(UUID jobId, int topK) {
-        return client.match(jobId, topK);
+        try {
+            return client.match(jobId, topK);
+        } catch (HttpClientErrorException.NotFound e) {
+            log.info("Job {} not indexed, vectorizing on demand", jobId);
+            JobDescription job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new ResourceNotFoundException("Job description not found"));
+            boolean vectorized = client.vectorizeJob(
+                job.getId(), job.getTitle(), job.getDescription(),
+                job.getRequirements(), job.getSkills()
+            );
+            if (!vectorized) {
+                throw e;
+            }
+            return client.match(jobId, topK);
+        }
     }
 }

--- a/ai-hiring-backend/src/test/java/com/aihiring/matching/MatchServiceTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/matching/MatchServiceTest.java
@@ -1,5 +1,7 @@
 package com.aihiring.matching;
 
+import com.aihiring.job.JobDescription;
+import com.aihiring.job.JobRepository;
 import com.aihiring.matching.dto.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -7,18 +9,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MatchServiceTest {
 
     @Mock AiMatchingClient client;
+    @Mock JobRepository jobRepository;
     @InjectMocks MatchService matchService;
 
     @Test
@@ -35,7 +42,49 @@ class MatchServiceTest {
         AiMatchResponse result = matchService.match(jobId, 10);
 
         assertThat(result).isSameAs(aiResponse);
-        assertThat(result.getResults()).hasSize(1);
         verify(client).match(jobId, 10);
+        verifyNoInteractions(jobRepository);
+    }
+
+    @Test
+    void match_on404_vectorizesAndRetries() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        JobDescription job = new JobDescription();
+        job.setId(jobId);
+        job.setTitle("t");
+        job.setDescription("d");
+        job.setRequirements("r");
+        job.setSkills("s");
+
+        String json = """
+            {"job_id": "%s", "results": []}""".formatted(jobId);
+        AiMatchResponse aiResponse = new ObjectMapper().readValue(json, AiMatchResponse.class);
+
+        when(client.match(eq(jobId), eq(10)))
+            .thenThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "nf", null, null, null))
+            .thenReturn(aiResponse);
+        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+        when(client.vectorizeJob(eq(jobId), any(), any(), any(), any())).thenReturn(true);
+
+        AiMatchResponse result = matchService.match(jobId, 10);
+
+        assertThat(result).isSameAs(aiResponse);
+        verify(client, times(2)).match(jobId, 10);
+        verify(client).vectorizeJob(jobId, "t", "d", "r", "s");
+    }
+
+    @Test
+    void match_on404_whenVectorizeFails_rethrows() {
+        UUID jobId = UUID.randomUUID();
+        JobDescription job = new JobDescription();
+        job.setId(jobId);
+
+        when(client.match(eq(jobId), eq(10)))
+            .thenThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "nf", null, null, null));
+        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+        when(client.vectorizeJob(eq(jobId), any(), any(), any(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> matchService.match(jobId, 10))
+            .isInstanceOf(HttpClientErrorException.NotFound.class);
     }
 }


### PR DESCRIPTION
## Summary
- Legacy JDs on staging (created before the async indexing listener existed) return 404 from the AI matching service
- Silent-fail path in AiMatchingClient.vectorizeJob also produces unindexed JDs without any retry
- Fix: on HTTP 404 from match, look up the JD, vectorize synchronously, retry once

## Root cause
Async `@EventListener` indexing (`AiMatchingEventListener.onJobSaved`) was added 2026-03-19. JDs created before this listener were never vectorized. Additionally, `AiMatchingClient.vectorizeJob` swallows `RestClientException` — any transient failure at save time leaves the JD unindexed forever, with no `status` flag to detect it.

## Changes
- `MatchService.match`: catch `HttpClientErrorException.NotFound`, lazily vectorize via `AiMatchingClient.vectorizeJob`, retry match
- Unit tests for happy path, 404→vectorize→retry, and vectorize-failure rethrow

## Test plan
- [x] `./gradlew test --tests MatchServiceTest` passes locally
- [ ] Merge → staging deploys → click 'Find Matching Resumes' on a legacy JD → results return

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)