### PR TITLE
fix: AI Matching导出和显示重复的多条Resumes

### DIFF
--- a/ai-matching-service/routers/match.py
+++ b/ai-matching-service/routers/match.py
@@ -34,6 +34,29 @@ async def match_resumes(request: MatchRequest):
             highlights=score.highlights,
         )
 
-    results = await asyncio.gather(*[score_candidate(c) for c in candidates])
-    ranked = sorted(results, key=lambda r: r.llm_score, reverse=True)
-    return MatchResponse(job_id=request.job_id, results=ranked[: request.top_k])
+    scored = await asyncio.gather(*[score_candidate(c) for c in candidates])
+    ranked = sorted(
+        zip(scored, candidates), key=lambda pair: pair[0].llm_score, reverse=True
+    )
+
+    # Issue #115: collapse duplicates so each unique resume — both by id and by
+    # raw content (re-uploaded files produce distinct ids for identical text) —
+    # appears at most once. Highest LLM score wins because list is pre-sorted.
+    deduped: list[MatchResultItem] = []
+    seen_ids: set[str] = set()
+    seen_text_hashes: set[str] = set()
+    for item, candidate in ranked:
+        if item.resume_id in seen_ids:
+            continue
+        raw_text = (candidate.payload.get("raw_text") or "").strip()
+        text_key = raw_text if raw_text else None
+        if text_key and text_key in seen_text_hashes:
+            continue
+        seen_ids.add(item.resume_id)
+        if text_key:
+            seen_text_hashes.add(text_key)
+        deduped.append(item)
+        if len(deduped) >= request.top_k:
+            break
+
+    return MatchResponse(job_id=request.job_id, results=deduped)

--- a/ai-matching-service/tests/test_match.py
+++ b/ai-matching-service/tests/test_match.py
@@ -96,3 +96,54 @@ def test_match_result_includes_vector_score(client):
 def test_match_top_k_max_50(client):
     response = client.post("/match", json={"job_id": "job-999", "top_k": 51})
     assert response.status_code == 422
+
+
+def test_match_dedupes_resumes_with_identical_content(client):
+    """Issue #115: same resume content (e.g. re-uploaded file producing distinct
+    resume IDs) must collapse to a single result, keeping the highest LLM score."""
+    job_record = _make_job_record("job-dup")
+    candidates = [
+        _make_scored_point("resume-a", 0.90, "Alice — Java, 5y"),
+        _make_scored_point("resume-b", 0.88, "Alice — Java, 5y"),  # duplicate content
+        _make_scored_point("resume-c", 0.70, "Bob — Python"),
+    ]
+    scores = [
+        MatchScore(score=70, reasoning="ok", highlights=[]),
+        MatchScore(score=85, reasoning="great", highlights=["Java"]),
+        MatchScore(score=60, reasoning="partial", highlights=[]),
+    ]
+
+    with patch("services.vector_store.get_job_record", new=AsyncMock(return_value=job_record)), \
+         patch("services.vector_store.search_resumes", new=AsyncMock(return_value=candidates)), \
+         patch("services.llm.score_match", new=AsyncMock(side_effect=scores)):
+        response = client.post("/match", json={"job_id": "job-dup", "top_k": 5})
+
+    data = response.json()
+    assert len(data["results"]) == 2
+    resume_ids = [r["resume_id"] for r in data["results"]]
+    assert "resume-b" in resume_ids  # higher-scored duplicate kept
+    assert "resume-a" not in resume_ids
+    assert "resume-c" in resume_ids
+
+
+def test_match_dedupes_repeated_resume_id(client):
+    """Defensive: if vector search returns the same resume_id twice, only one survives."""
+    job_record = _make_job_record("job-rep")
+    candidates = [
+        _make_scored_point("resume-x", 0.91, "X content"),
+        _make_scored_point("resume-x", 0.80, "X content"),
+    ]
+    scores = [
+        MatchScore(score=75, reasoning="a", highlights=[]),
+        MatchScore(score=82, reasoning="b", highlights=[]),
+    ]
+
+    with patch("services.vector_store.get_job_record", new=AsyncMock(return_value=job_record)), \
+         patch("services.vector_store.search_resumes", new=AsyncMock(return_value=candidates)), \
+         patch("services.llm.score_match", new=AsyncMock(side_effect=scores)):
+        response = client.post("/match", json={"job_id": "job-rep", "top_k": 5})
+
+    data = response.json()
+    assert len(data["results"]) == 1
+    assert data["results"][0]["resume_id"] == "resume-x"
+    assert data["results"][0]["llm_score"] == 82


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #115: AI Matching导出和显示重复的多条Resumes

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/115

## Changes

- fix: dedupe AI matching results by resume id and content

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #115
issue: #115