### PR TITLE
feat: auto-notify Claude on new autofix issues

### DIFF
--- a/.github/workflows/notify-new-issue.yml
+++ b/.github/workflows/notify-new-issue.yml
@@ -1,0 +1,39 @@
+name: Notify Autofix Issue
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  notify:
+    if: contains(github.event.issue.labels.*.name, 'autofix')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write to VPS notification queue
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: ISSUE_NUMBER,ISSUE_TITLE,ISSUE_LABELS,ISSUE_URL,ISSUE_BODY
+          script: |
+            python3 << 'PYEOF'
+            import json, datetime, os
+            entry = {
+              'id': f'issue-{os.environ["ISSUE_NUMBER"]}',
+              'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+              'read': False,
+              'type': 'new_issue',
+              'message': f'🔧 Autofix issue #{os.environ["ISSUE_NUMBER"]}: {os.environ["ISSUE_TITLE"]}',
+              'details': f'Labels: {os.environ.get("ISSUE_LABELS","")}\nURL: {os.environ["ISSUE_URL"]}\n\n{os.environ.get("ISSUE_BODY","")[:500]}',
+              'run_url': os.environ["ISSUE_URL"]
+            }
+            with open('/opt/ai-hiring/notifications/queue.jsonl', 'a') as f:
+                f.write(json.dumps(entry) + '\n')
+            PYEOF
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_BODY: ${{ github.event.issue.body }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,18 @@ JWT-based: access token (2h TTL) + refresh token (7d TTL).
 
 ## Git Workflow
 
+- **所有进入 master 的改动都必须经过用户 review。** 这是不可违反的基本规则。无论改动多小、多紧急，一律创建 PR 等用户 merge，没有例外。
 - 永远不要直接 push 到 master。必须创建 feature branch 并开 PR。
 - 永远不要自行 merge PR。等用户 review 后由用户 merge。
-- commit 只包含当前任务相关的文件，不要捆绑无关改动。
+- **永远不要用 `git add -A` 或 `git add .`。** 必须逐个指定要提交的文件（`git add file1 file2`），避免把 uploads、__pycache__、临时文件等无关内容提交进去。
+- commit 只包含当前任务相关的文件，不要捆绑无关改动。提交前用 `git diff --cached --stat` 确认文件列表。
+- 已 merge 的 PR 分支不能再 push 新 commit（不会进入 master）。如果有后续修改，必须开新分支、新 PR。
+
+## Evidence & Screenshot Rules
+
+- 在 GitHub issue/PR 中附截图时，**必须使用 GitHub 能渲染的 URL**。不能用本地路径（如 `test-results/xxx.png`），GitHub 上看不到。
+- 正确做法：将截图 commit 到仓库（如 `docs/evidence/`）并用 `https://raw.githubusercontent.com/...` 链接，或通过 GitHub issue 上传获取 URL。
+- 关闭 issue 前必须确认截图在 GitHub 页面上能正确显示。
 
 ## Execution Principles
 


### PR DESCRIPTION
## Summary

When a GitHub issue with the `autofix` label is created or labeled, automatically notify Claude Code session on VPS so it can start fixing.

## Flow

```
New issue (with autofix label)
    ↓
GitHub Actions: notify-new-issue.yml triggers
    ↓
SSH to VPS → write to /opt/ai-hiring/notifications/queue.jsonl
    ↓
Claude session hook detects notification
    ↓
Claude auto: read issue → analyze → fix → test → create PR
    ↓
Wait for user review and merge
```

## Changes

1. **`.github/workflows/notify-new-issue.yml`** — New workflow triggered on `issues: [opened, labeled]`, filtered to `autofix` label only
2. **`CLAUDE.md`** — Add rule: all master changes require user review (no exceptions)
3. **`/opt/ai-hiring/scripts/check-notifications.sh`** (VPS, already updated) — Handle `type: new_issue` notifications with autofix-specific prompt

## Test plan

- [ ] Create a test issue with `autofix` label → verify notification appears in queue.jsonl
- [ ] Verify Claude session picks up the notification and starts analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)