### PR TITLE
fix: deduplicate AI matching results (issue #115)

### DIFF
--- a/ai-matching-service/routers/match.py
+++ b/ai-matching-service/routers/match.py
@@ -12,9 +12,21 @@ async def match_resumes(request: MatchRequest):
     if job_record is None:
         raise HTTPException(status_code=404, detail="Job not found in vector store")
 
-    candidates = await vector_store.search_resumes(job_record.vector, request.top_k * 2)
-    if not candidates:
+    raw_candidates = await vector_store.search_resumes(job_record.vector, request.top_k * 5)
+    if not raw_candidates:
         return MatchResponse(job_id=request.job_id, results=[])
+
+    # Deduplicate by raw_text content — keep highest vector score per unique resume
+    seen_texts: dict[str, object] = {}
+    candidates = []
+    for c in raw_candidates:
+        text = c.payload.get("raw_text", "")
+        text_key = text[:200]  # Use first 200 chars as dedup key
+        if text_key not in seen_texts:
+            seen_texts[text_key] = True
+            candidates.append(c)
+        if len(candidates) >= request.top_k * 2:
+            break
 
     payload = job_record.payload
     job_text = f"Title: {payload['title']}\n\nDescription:\n{payload['description']}"

--- a/ai-matching-service/tests/test_match.py
+++ b/ai-matching-service/tests/test_match.py
@@ -73,8 +73,8 @@ def test_match_overfetches_from_qdrant(client):
          patch("services.vector_store.search_resumes", new=search_mock):
         client.post("/match", json={"job_id": "job-003", "top_k": 5})
 
-    # Should search for top_k * 2 = 10 candidates
-    search_mock.assert_called_once_with(job_record.vector, 10)
+    # Should search for top_k * 5 = 25 candidates (overfetch for dedup)
+    search_mock.assert_called_once_with(job_record.vector, 25)
 
 
 def test_match_result_includes_vector_score(client):
@@ -91,6 +91,34 @@ def test_match_result_includes_vector_score(client):
     assert result["resume_id"] == "resume-x"
     assert result["vector_score"] == 0.93
     assert result["llm_score"] == 88
+
+
+def test_match_deduplicates_same_resume(client):
+    job_record = _make_job_record("job-005")
+    # 3 candidates but two have identical raw_text (duplicate uploads)
+    candidates = [
+        _make_scored_point("resume-1", 0.90, "Alice is a Java engineer with 5 years experience"),
+        _make_scored_point("resume-2", 0.88, "Alice is a Java engineer with 5 years experience"),  # duplicate
+        _make_scored_point("resume-3", 0.85, "Bob is a Python developer"),
+    ]
+    scores = [
+        MatchScore(score=80, reasoning="Good", highlights=["Java"]),
+        MatchScore(score=70, reasoning="OK", highlights=["Python"]),
+    ]
+
+    with patch("services.vector_store.get_job_record", new=AsyncMock(return_value=job_record)), \
+         patch("services.vector_store.search_resumes", new=AsyncMock(return_value=candidates)), \
+         patch("services.llm.score_match", new=AsyncMock(side_effect=scores)):
+        response = client.post("/match", json={"job_id": "job-005", "top_k": 10})
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    # Should only have 2 unique resumes, not 3
+    assert len(results) == 2
+    resume_ids = [r["resume_id"] for r in results]
+    assert "resume-1" in resume_ids  # kept (higher vector score)
+    assert "resume-2" not in resume_ids  # deduped
+    assert "resume-3" in resume_ids
 
 
 def test_match_top_k_max_50(client):


### PR DESCRIPTION
## Summary

AI Matching returns duplicate resumes because the same resume was uploaded multiple times (by E2E tests and smoke tests), creating multiple entries in the vector store.

## Root Cause

- Database has 100 resumes but only 16 unique file names
- `smoke.txt` × 50, `覃启航.pdf` × 13, etc.
- Vector store has 38 points — many are duplicates of the same content
- `search_resumes(top_k * 2)` returns duplicates, all scored separately

## Fix

Deduplicate candidates by `raw_text` content (first 200 chars as dedup key) after vector search, before LLM scoring:

```python
# Before: all duplicates scored → duplicates in results
candidates = await vector_store.search_resumes(vector, top_k * 2)

# After: dedup first → only unique resumes scored
raw_candidates = await vector_store.search_resumes(vector, top_k * 5)
# ... deduplicate by raw_text ...
```

## Changes

- `ai-matching-service/routers/match.py` — Add dedup logic, increase overfetch to 5x
- `ai-matching-service/tests/test_match.py` — Add `test_match_deduplicates_same_resume`, update overfetch test

## Test plan

- [x] 7/7 AI service tests pass (including new dedup test)
- [ ] CI passes
- [ ] After deploy: verify on staging — no duplicate candidates in results

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)