### PR TITLE
ci: resolve short SHAs and verify images before prod deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,13 +14,38 @@ env:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    outputs:
+      resolved_version: ${{ steps.resolve.outputs.sha }}
     steps:
-      - name: Verify images exist
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Resolve version to full SHA
+        id: resolve
         run: |
-          echo "Verifying images for version ${{ inputs.version }}"
-          echo "Backend: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/ai-hiring-backend:${{ inputs.version }}"
-          echo "AI Service: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/ai-matching-service:${{ inputs.version }}"
-          echo "Frontend: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/ai-hiring-frontend:${{ inputs.version }}"
+          INPUT="${{ inputs.version }}"
+          if ! SHA=$(git rev-parse --verify "${INPUT}^{commit}" 2>/dev/null); then
+            echo "::error::Cannot resolve '${INPUT}' to a commit SHA"
+            exit 1
+          fi
+          echo "Resolved '${INPUT}' -> ${SHA}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - name: Verify images exist in registry
+        env:
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          set -e
+          for IMG in ai-hiring-backend ai-matching-service ai-hiring-frontend; do
+            REF="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${IMG}:${SHA}"
+            echo "Checking ${REF}..."
+            if ! docker manifest inspect "${REF}" > /dev/null 2>&1; then
+              echo "::error::Image not found in registry: ${REF}"
+              exit 1
+            fi
+          done
+          echo "All images verified."
 
   deploy:
     needs: verify
@@ -69,7 +94,7 @@ jobs:
             cp /tmp/ai-hiring-scripts/scripts/rollback.sh /opt/ai-hiring/scripts/rollback.sh
             chmod +x /opt/ai-hiring/scripts/deploy.sh /opt/ai-hiring/scripts/health-check.sh /opt/ai-hiring/scripts/rollback.sh
             export OPENAI_API_KEY="$OPENAI_API_KEY"
-            /opt/ai-hiring/scripts/deploy.sh prod ${{ inputs.version }} "$GHCR_TOKEN"
+            /opt/ai-hiring/scripts/deploy.sh prod ${{ needs.verify.outputs.resolved_version }} "$GHCR_TOKEN"
       - name: Health check
         run: |
           sleep 45
@@ -118,7 +143,7 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
 
   alert:
-    needs: [deploy, rollback]
+    needs: [verify, deploy, rollback]
     if: always() && needs.deploy.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
@@ -128,14 +153,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = '${{ inputs.version }}'.substring(0, 7);
+            const sha = '${{ needs.verify.outputs.resolved_version }}'.substring(0, 7);
             const prevSha = '${{ needs.deploy.outputs.previous_version }}'.substring(0, 7);
             const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
             const rollbackStatus = '${{ needs.rollback.result }}';
 
             const title = `Production deploy failed and rolled back: ${sha}`;
             const body = `## Production Deployment Failure\n\n` +
-              `- **Attempted version**: \`${{ inputs.version }}\`\n` +
+              `- **Attempted version**: \`${{ needs.verify.outputs.resolved_version }}\`\n` +
               `- **Rolled back to**: \`${{ needs.deploy.outputs.previous_version }}\`\n` +
               `- **Rollback status**: ${rollbackStatus}\n` +
               `- **Workflow run**: ${runUrl}\n\n` +


### PR DESCRIPTION
## Summary
- Prevents the failure mode from today's prod deploy attempt for `e403e1b`: the short SHA did not match GHCR image tags (which use the full SHA), so the deploy failed mid-way through SSH + rollback had to run.
- `verify` job now resolves the input to a full commit SHA via `git rev-parse` (accepts short SHAs, tags, branches) and asserts all three image manifests exist in GHCR before any deploy work starts.
- `deploy` and `alert` jobs consume `needs.verify.outputs.resolved_version` so the VPS pulls the canonical tag and failure reports are accurate.

## Motivation
Production deploy run [24759367674](https://github.com/yukunchen/aihiringsystem/actions/runs/24759367674) failed on `docker pull` with:
`failed to resolve reference "ghcr.io/yukunchen/ai-matching-service:e403e1b": not found`
The retry with the full SHA succeeded ([24759394639](https://github.com/yukunchen/aihiringsystem/actions/runs/24759394639)). This PR makes the workflow fail-fast in CI instead of on the VPS, and removes the need for the operator to hand-paste a full SHA.

## Test plan
- [ ] Trigger `deploy-prod.yml` with a short SHA (e.g. `e403e1b`) and confirm the `verify` job resolves it and succeeds.
- [ ] Trigger with a bogus SHA (e.g. `deadbee`) and confirm the `verify` job fails fast with a clear error.
- [ ] Trigger with a valid commit whose images have not been built yet and confirm `verify` fails on the manifest check (image-not-found), not on SSH.
- [ ] Trigger with the full SHA (current behavior) and confirm the deploy still succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)