### PR TITLE
fix: Batch上传Resue，日期显示invalid

### DIFF
--- a/frontend/src/api/resumes.test.ts
+++ b/frontend/src/api/resumes.test.ts
@@ -84,7 +84,7 @@ describe('resumes API', () => {
 });
 
 it('uploadResume() POSTs multipart and returns resume on success', async () => {
-    const mockResume = { id: 'r1', fileName: 'cv.pdf', fileType: 'PDF', source: 'MANUAL', status: 'UPLOADED', uploadedAt: '2026-03-01T00:00:00Z' };
+    const mockResume = { id: 'r1', fileName: 'cv.pdf', fileType: 'PDF', source: 'MANUAL', status: 'UPLOADED', createdAt: '2026-03-01T00:00:00Z' };
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
       ok: true,
       status: 200,

--- a/frontend/src/api/resumes.ts
+++ b/frontend/src/api/resumes.ts
@@ -9,7 +9,7 @@ export interface ResumeListItem {
   fileType: string;
   source: string;
   status: string;
-  uploadedAt: string;
+  createdAt: string;
 }
 
 export async function listResumes(page: number, size: number): Promise<Page<ResumeListItem>> {

--- a/frontend/src/pages/resumes/ResumeListPage.test.tsx
+++ b/frontend/src/pages/resumes/ResumeListPage.test.tsx
@@ -1,5 +1,28 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { STATUS_COLORS, STATUS_LABELS } from './resumeStatus';
+import ResumeListPage from './ResumeListPage';
+import * as resumesApi from '../../api/resumes';
+
+vi.mock('../../api/resumes');
+
+describe('ResumeListPage date column', () => {
+  it('renders Uploaded date from createdAt (not Invalid Date)', async () => {
+    vi.mocked(resumesApi.listResumes).mockResolvedValueOnce({
+      content: [{
+        id: 'r1', fileName: 'cv.pdf', fileType: 'PDF', source: 'MANUAL',
+        status: 'UPLOADED', createdAt: '2026-04-20T10:00:00Z',
+      }],
+      totalElements: 1, totalPages: 1, number: 0, size: 10,
+    });
+    render(<MemoryRouter><ResumeListPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByText('cv.pdf')).toBeInTheDocument());
+    const expected = new Date('2026-04-20T10:00:00Z').toLocaleDateString();
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument();
+  });
+});
 
 describe('STATUS_LABELS', () => {
   it('maps UPLOADED to Uploaded', () => {

--- a/frontend/src/pages/resumes/ResumeListPage.tsx
+++ b/frontend/src/pages/resumes/ResumeListPage.tsx
@@ -60,7 +60,7 @@ export default function ResumeListPage() {
       title: 'Status', dataIndex: 'status', key: 'status',
       render: (status: string) => <Tag color={STATUS_COLORS[status] ?? 'default'}>{STATUS_LABELS[status] ?? status}</Tag>,
     },
-    { title: 'Uploaded', dataIndex: 'uploadedAt', key: 'uploadedAt', render: (d: string) => new Date(d).toLocaleDateString() },
+    { title: 'Uploaded', dataIndex: 'createdAt', key: 'createdAt', render: (d: string) => (d ? new Date(d).toLocaleDateString() : '-') },
     {
       title: 'Actions', key: 'actions',
       render: (_: unknown, record: ResumeListItem) => (

--- a/frontend/src/pages/resumes/ResumeUploadPage.test.tsx
+++ b/frontend/src/pages/resumes/ResumeUploadPage.test.tsx
@@ -38,7 +38,7 @@ describe('ResumeUploadPage', () => {
 
   it('uploads file and redirects to /resumes on success', async () => {
     vi.mocked(resumesApi.uploadResume).mockResolvedValueOnce({
-      id: 'r1', fileName: 'cv.pdf', fileType: 'PDF', source: 'MANUAL', status: 'UPLOADED', uploadedAt: '',
+      id: 'r1', fileName: 'cv.pdf', fileType: 'PDF', source: 'MANUAL', status: 'UPLOADED', createdAt: '',
     });
 
     render(<MemoryRouter><ResumeUploadPage /></MemoryRouter>);


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #125: Batch上传Resue，日期显示invalid

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/125

## Changes

- fix: align resume list date field with backend (createdAt)

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #125
issue: #125