### PR TITLE
ci: resolve linked issues via GitHub PR API in staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -181,20 +181,51 @@ jobs:
           echo "" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Resolve linked issues
+        id: linked
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # Primary: use GitHub's native PR→issue linkage (captures "Fixes #N"
+          # from the PR body, which GitHub squash-merges strip out). The merge
+          # commit contains "(#<PR>)" from the PR number.
+          PR_NUM=$(echo "$COMMIT_MSG" | head -1 | grep -oE '\(#[0-9]+\)' | tail -1 | tr -d '(#)' || true)
+          ISSUES=""
+          if [ -n "$PR_NUM" ]; then
+            ISSUES=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
+              --json closingIssuesReferences \
+              --jq '.closingIssuesReferences[].number' 2>/dev/null || true)
+          fi
+
+          # Fallback: broaden regex to catch "issue #N", "fix #N", "(#N)", bare
+          # "#N" in the subject — covers PR titles that forgot "Fixes #N".
+          if [ -z "$ISSUES" ]; then
+            ISSUES=$(echo "$COMMIT_MSG" \
+              | grep -oiE '(closes?|fixes?|resolves?|issues?) ?#[0-9]+|\(#[0-9]+\)|#[0-9]+' \
+              | grep -oE '#[0-9]+' | tr -d '#' \
+              | sort -u || true)
+            # Exclude the PR number itself from the fallback results
+            if [ -n "$PR_NUM" ]; then
+              ISSUES=$(echo "$ISSUES" | grep -v "^${PR_NUM}$" || true)
+            fi
+          fi
+
+          ISSUES=$(echo "$ISSUES" | tr '\n' ' ' | xargs)
+          echo "issues=$ISSUES" >> "$GITHUB_OUTPUT"
+          echo "Linked issues: ${ISSUES:-<none>}"
+
       - name: Comment on linked issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PASS: ${{ steps.smoke.outputs.pass }}
           DETAILS: ${{ steps.smoke.outputs.details }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          ISSUES: ${{ steps.linked.outputs.issues }}
           SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # Extract issue numbers from commit message (e.g. "closes #21", "fixes #19")
-          ISSUES=$(echo "$COMMIT_MSG" | grep -oiE '(closes?|fixes?|resolves?) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
-
           if [ -z "$ISSUES" ]; then
-            echo "No linked issues found in commit message, skipping comment"
+            echo "No linked issues resolved, skipping comment"
             exit 0
           fi
 
@@ -248,22 +279,15 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Trigger Verifier Agent on VPS
-        if: steps.smoke.outputs.pass == 'true'
+        if: steps.smoke.outputs.pass == 'true' && steps.linked.outputs.issues != ''
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          envs: COMMIT_MSG
+          envs: ISSUES
           command_timeout: 2m
           script: |
-            ISSUES=$(echo "$COMMIT_MSG" \
-              | grep -oiE '(closes?|fixes?|resolves?) #[0-9]+' \
-              | grep -oE '#[0-9]+' | tr -d '#' || true)
-            if [ -z "$ISSUES" ]; then
-              echo "No linked issues in commit message — skipping verifier"
-              exit 0
-            fi
             for ISSUE in $ISSUES; do
               ISSUE_BODY=$(gh issue view "$ISSUE" --repo "${{ github.repository }}" --json body -q '.body' 2>/dev/null || echo "")
               LOG="/opt/ai-hiring/logs/verify-issue-${ISSUE}.log"
@@ -273,7 +297,7 @@ jobs:
               echo "Launched verifier for issue #$ISSUE (PID $!) — log: $LOG"
             done
         env:
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          ISSUES: ${{ steps.linked.outputs.issues }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   e2e:


### PR DESCRIPTION
## Summary
Today's PR #127 (fixing issue #125) merged cleanly, but the \`deploy-staging.yml\` steps \`Comment on linked issues\` and \`Trigger Verifier Agent on VPS\` both silently did nothing. Root cause: both steps grep the merge commit message for \`(closes|fixes|resolves) #N\`, but GitHub's squash-merge uses the PR title as the commit message and strips the PR body (which had \`Fixes #125\`). The PR title was \`... (issue #125) (#127)\` — regex miss.

## Fix
- Add a dedicated \`Resolve linked issues\` step that:
  1. Extracts the PR number from the merge commit subject (\`(#<PR>)\`)
  2. Calls \`gh pr view <PR> --json closingIssuesReferences\` — GitHub's authoritative source for PR→issue linkage, capturing the \`Fixes #N\` in the PR body that squash-merges erase
  3. Falls back to a broadened regex (\`issue #N\`, \`(#N)\`, bare \`#N\`) for direct pushes with no PR; excludes the PR number itself from fallback matches
- Expose resolved list as \`steps.linked.outputs.issues\`
- \`Comment on linked issues\` and \`Trigger Verifier Agent\` both consume that output instead of re-greping

## Test plan
- [ ] Merge a PR with \`Fixes #N\` in its body (e.g., open a throwaway PR closing a test issue) → verify staging deploy comments on #N + launches verifier.
- [ ] Merge a PR **without** \`Fixes #N\` but with \`(issue #N)\` in title → fallback path picks up #N.
- [ ] Merge an unrelated PR (no issue link) → both steps skip cleanly with informative log.
- [ ] Direct push to master with \`fixes #N\` in commit message → fallback path picks up #N.

🤖 Generated with [Claude Code](https://claude.com/claude-code)