### PR TITLE
feat: autofix advisory lock to prevent duplicate-fix races

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,20 @@ JWT-based: access token (2h TTL) + refresh token (7d TTL).
 - dev/staging/prod 使用独立的 Docker 内部网络，禁止共享网络导致 DNS 冲突。
 - 部署后必须通过前端端口验证，不能只验证 backend 直连端口。
 
+## Autofix Workflow (issue-driven autonomous fixes)
+
+Before starting work on an `autofix`-labeled issue picked up from the VPS notification queue, **always claim it first**:
+
+```bash
+scripts/autofix-claim.sh <issue-number>
+```
+
+The script checks that the issue is still OPEN, has no `autofix-in-progress` label, and has no open PR that would close it; then it adds the `autofix-in-progress` label as an advisory lock. If it exits non-zero, skip the issue — another session is already on it or it has been resolved. This prevents the duplicate-fix race that produced PRs #126 and #127 for issue #125.
+
+Reason: `notify-new-issue.yml` can fire multiple times for the same issue, and there is no coordination between VPS sessions. The label acts as a cheap cross-session mutex visible on GitHub.
+
+The label is removed automatically when the fixing PR is merged (because the issue closes). If a session abandons the work without a PR, run `scripts/autofix-release.sh <issue-number>` to free the lock.
+
 ## Git Workflow
 
 - **所有进入 master 的改动都必须经过用户 review。** 这是不可违反的基本规则。无论改动多小、多紧急，一律创建 PR 等用户 merge，没有例外。

--- a/scripts/autofix-claim.sh
+++ b/scripts/autofix-claim.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Advisory lock for autofix: check whether issue #N is still actionable,
+# then claim it by adding the `autofix-in-progress` label. Prevents two
+# concurrent Claude sessions from fixing the same issue (which happened
+# with issue #125 -> PRs #126 and #127 both landing the same fix).
+#
+# Usage:
+#   autofix-claim.sh <issue-number> [repo]
+#
+# Exit codes:
+#   0  — claim acquired, caller should proceed with the fix
+#   1  — already claimed / closed / has open PR / not found; caller should skip
+#   2  — usage error or gh CLI failure
+set -euo pipefail
+
+ISSUE="${1:-}"
+REPO="${2:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo '')}"
+LOCK_LABEL="autofix-in-progress"
+
+if [[ -z "$ISSUE" || -z "$REPO" ]]; then
+    echo "usage: $0 <issue-number> [owner/repo]" >&2
+    exit 2
+fi
+
+echo "Checking issue #${ISSUE} in ${REPO}..."
+
+ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json state,labels 2>/dev/null || echo '')
+if [[ -z "$ISSUE_JSON" ]]; then
+    echo "  issue not found or gh error — skip"
+    exit 1
+fi
+
+STATE=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('state',''))")
+LABELS=$(echo "$ISSUE_JSON" | python3 -c "import sys,json; print(','.join(l['name'] for l in json.load(sys.stdin).get('labels',[])))")
+
+if [[ "$STATE" != "OPEN" ]]; then
+    echo "  state=${STATE} — skip"
+    exit 1
+fi
+
+if [[ ",${LABELS}," == *",${LOCK_LABEL},"* ]]; then
+    echo "  already has ${LOCK_LABEL} label — another session is on it, skip"
+    exit 1
+fi
+
+# Any open PR that closes this issue? Use GitHub's native linkage.
+OPEN_PRS=$(gh pr list --repo "$REPO" --state open --json number,closingIssuesReferences \
+    --jq "[.[] | select(.closingIssuesReferences[]?.number == ${ISSUE}) | .number] | join(\",\")" 2>/dev/null || echo '')
+if [[ -n "$OPEN_PRS" ]]; then
+    echo "  open PR(s) already close this issue: #${OPEN_PRS} — skip"
+    exit 1
+fi
+
+# Ensure the lock label exists, then add it. The add itself is the claim.
+gh label create "$LOCK_LABEL" --repo "$REPO" --color fbca04 \
+    --description "An autofix agent is currently working on this issue" 2>/dev/null || true
+
+if gh issue edit "$ISSUE" --repo "$REPO" --add-label "$LOCK_LABEL" >/dev/null 2>&1; then
+    echo "  claimed issue #${ISSUE}"
+    exit 0
+fi
+
+echo "  failed to add lock label — skip"
+exit 1

--- a/scripts/autofix-release.sh
+++ b/scripts/autofix-release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Release the autofix advisory lock on issue #N by removing the
+# `autofix-in-progress` label. Safe to run even if the label is absent.
+#
+# Usage:
+#   autofix-release.sh <issue-number> [repo]
+set -euo pipefail
+
+ISSUE="${1:-}"
+REPO="${2:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo '')}"
+LOCK_LABEL="autofix-in-progress"
+
+if [[ -z "$ISSUE" || -z "$REPO" ]]; then
+    echo "usage: $0 <issue-number> [owner/repo]" >&2
+    exit 2
+fi
+
+gh issue edit "$ISSUE" --repo "$REPO" --remove-label "$LOCK_LABEL" >/dev/null 2>&1 || true
+echo "released autofix lock on #${ISSUE}"


### PR DESCRIPTION
## Summary
Issue #125 produced two parallel fixes (PR #126 landing first, PR #127 landing minutes later) because:
1. \`notify-new-issue.yml\` fired 3 times in 1 second (one \`opened\` + two \`labeled\` events) with no dedup — partially addressed in PR #128.
2. Two VPS Claude sessions independently consumed notifications and started working on the same issue with no coordination.

This PR addresses (2) with a cheap, cross-session advisory mutex using a GitHub label (\`autofix-in-progress\`).

## What's added
- \`scripts/autofix-claim.sh <N>\` — claims issue #N. Checks:
  1. Issue state is \`OPEN\` (skip if CLOSED)
  2. Issue does not already carry \`autofix-in-progress\`
  3. No open PR references this issue via \`closingIssuesReferences\`
  If all clear, adds the label (the add is the claim). Returns 0 on claim acquired, non-zero otherwise.
- \`scripts/autofix-release.sh <N>\` — removes the label. Idempotent; safe to run twice.
- \`CLAUDE.md\` — documents the claim-before-work rule under a new **Autofix Workflow** section.

Label is auto-cleaned when the fixing PR is merged (the issue closes). If a session abandons work without a PR, operators can run the release script.

## Design choices
- **Label-as-lock**: atomic enough (GitHub's label add is a single API call), visible on the GitHub UI, no extra infra. Compared to a file on VPS, it works across hosts and survives VPS restarts.
- **No TTL**: a genuinely stuck session will leave a stale lock; we accept that trade-off in exchange for simplicity. Manual release is one command.
- **Open-PR check**: catches the \`(1.5)\` case where session A already pushed a PR but session B is just now waking up. Cheaper than a post-merge dedup.

## Test plan
- [ ] Manual claim on a live test issue: \`scripts/autofix-claim.sh <N>\` → exit 0, label appears on issue.
- [ ] Re-run the same command → exit 1, label unchanged.
- [ ] Open a throwaway PR with \`Fixes #<N>\` in the body, then re-run \`autofix-claim.sh <N>\` against a fresh issue without the label → exit 1, logs mention the open PR.
- [ ] \`autofix-release.sh <N>\` removes the label; a subsequent claim succeeds.
- [ ] Run release on an issue that never had the label → exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)