### PR TITLE
feat: orchestrator PR-ready pings + role-aware notification hook

### DIFF
--- a/.github/workflows/notify-pr-ready.yml
+++ b/.github/workflows/notify-pr-ready.yml
@@ -1,0 +1,73 @@
+name: Notify PR Ready
+
+# Fires when a PR is opened (or re-opened) so the orchestrator Claude
+# session knows a fix is waiting for human review. Without this, the
+# autofix loop stalls invisibly between "fixer opens PR" and "user
+# merges" — the fixer agent moves on and nothing pings the human.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Write orchestrator notification to VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: PR_NUMBER,PR_TITLE,PR_URL,PR_BODY,PR_AUTHOR,PR_BRANCH
+          script: |
+            python3 << 'PYEOF'
+            import json, datetime, os
+            queue_path = '/opt/ai-hiring/notifications/orchestrator-queue.jsonl'
+            entry_id = f'pr-{os.environ["PR_NUMBER"]}'
+
+            # Dedup: open → ready_for_review can fire for the same PR.
+            try:
+                with open(queue_path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            if json.loads(line).get('id') == entry_id:
+                                print(f'Skip duplicate notification for {entry_id}')
+                                raise SystemExit(0)
+                        except json.JSONDecodeError:
+                            continue
+            except FileNotFoundError:
+                pass
+
+            body_preview = (os.environ.get('PR_BODY') or '')[:400]
+            entry = {
+              'id': entry_id,
+              'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+              'read': False,
+              'type': 'pr_ready',
+              'target': 'orchestrator',
+              'message': f'📬 PR #{os.environ["PR_NUMBER"]} ready for review: {os.environ["PR_TITLE"]}',
+              'details': (
+                f'Author: {os.environ.get("PR_AUTHOR","")}\n'
+                f'Branch: {os.environ.get("PR_BRANCH","")}\n'
+                f'URL: {os.environ["PR_URL"]}\n\n'
+                f'{body_preview}'
+              ),
+              'run_url': os.environ['PR_URL']
+            }
+            os.makedirs(os.path.dirname(queue_path), exist_ok=True)
+            with open(queue_path, 'a') as f:
+                f.write(json.dumps(entry) + '\n')
+            print(f'Wrote {entry_id} to orchestrator queue')
+            PYEOF
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,17 +58,25 @@ JWT-based: access token (2h TTL) + refresh token (7d TTL).
 
 ## Autofix Workflow (issue-driven autonomous fixes)
 
-Before starting work on an `autofix`-labeled issue picked up from the VPS notification queue, **always claim it first**:
+**Session roles.** Two kinds of Claude sessions share this system:
+- **Fixer** — long-running background session on the VPS. Consumes `new_issue` notifications, claims, writes fixes, opens PRs. Should run with `CLAUDE_ROLE=fixer`.
+- **Orchestrator** — interactive session talking to the human. Consumes `pr_ready` pings (so the human is told a PR is waiting) and deploy notifications. Should run with `CLAUDE_ROLE=orchestrator`.
+
+The notification hook (`scripts/check-notifications.sh`, canonical source in this repo; deployed to `/opt/ai-hiring/scripts/`) filters queue entries by role so the fixer does not swallow pings meant for the human, and vice versa. Notifications flow:
+- `/opt/ai-hiring/notifications/queue.jsonl` — `new_issue`, deploy events (fixer + fallback).
+- `/opt/ai-hiring/notifications/orchestrator-queue.jsonl` — `pr_ready` and future orchestrator-only events.
+
+**Claim before work (fixer).** Before starting on an `autofix`-labeled issue:
 
 ```bash
 scripts/autofix-claim.sh <issue-number>
 ```
 
-The script checks that the issue is still OPEN, has no `autofix-in-progress` label, and has no open PR that would close it; then it adds the `autofix-in-progress` label as an advisory lock. If it exits non-zero, skip the issue — another session is already on it or it has been resolved. This prevents the duplicate-fix race that produced PRs #126 and #127 for issue #125.
-
-Reason: `notify-new-issue.yml` can fire multiple times for the same issue, and there is no coordination between VPS sessions. The label acts as a cheap cross-session mutex visible on GitHub.
+The script checks that the issue is still OPEN, has no `autofix-in-progress` label, and has no open PR that would close it; then it adds the `autofix-in-progress` label as an advisory lock. If it exits non-zero, skip the issue — another session is already on it or it has been resolved.
 
 The label is removed automatically when the fixing PR is merged (because the issue closes). If a session abandons the work without a PR, run `scripts/autofix-release.sh <issue-number>` to free the lock.
+
+**PR-ready pings (orchestrator).** `.github/workflows/notify-pr-ready.yml` writes a `pr_ready` entry to the orchestrator queue whenever a non-draft PR is opened, so the orchestrator surfaces pending reviews to the human on the next prompt. Do not merge on the human's behalf — per the Git Workflow rule below, every merge is a human decision.
 
 ## Git Workflow
 

--- a/scripts/check-notifications.sh
+++ b/scripts/check-notifications.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Canonical source for /opt/ai-hiring/scripts/check-notifications.sh on the VPS.
+# Used by Claude Code Stop and UserPromptSubmit hooks to inject queued
+# notifications as additional context.
+#
+# Role filtering:
+#   CLAUDE_ROLE=fixer         → consumes only `type: new_issue` from queue.jsonl.
+#                               Ignores orchestrator-queue.jsonl entirely. This
+#                               is what the long-running background session
+#                               that runs autofix-claim.sh + opens PRs should
+#                               use so it does not gobble review pings meant
+#                               for the human.
+#   CLAUDE_ROLE=orchestrator  → consumes `pr_ready` / deploy notifications
+#                               from orchestrator-queue.jsonl first, falls
+#                               back to queue.jsonl. This is what interactive
+#                               user-facing sessions should use so the human
+#                               hears about PRs ready for review, prod
+#                               health, etc.
+#   unset / other             → legacy behavior: reads queue.jsonl, consumes
+#                               any unread entry regardless of type.
+#
+# Exit codes follow the hook semantics per event (set from stdin):
+#   Stop event         → exit 2 wakes Claude and sends reason as context.
+#   UserPromptSubmit   → exit 0 with additionalContext (exit 2 would block
+#                        the user's prompt).
+
+set -u
+
+QUEUE_ISSUES="/opt/ai-hiring/notifications/queue.jsonl"
+QUEUE_ORCHESTRATOR="/opt/ai-hiring/notifications/orchestrator-queue.jsonl"
+LOCK="/tmp/ai-hiring-notify.lock"
+ROLE="${CLAUDE_ROLE:-}"
+
+# Capture hook input (Claude Code passes JSON on stdin).
+HOOK_INPUT=""
+if [ ! -t 0 ]; then
+    HOOK_INPUT=$(cat)
+fi
+HOOK_EVENT=$(printf '%s' "$HOOK_INPUT" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('hook_event_name',''))
+except Exception:
+    print('')
+" 2>/dev/null)
+[ -z "$HOOK_EVENT" ] && HOOK_EVENT="Stop"
+
+# Serialize access across concurrent hook invocations.
+exec 9>"$LOCK"
+flock -n 9 || exit 0
+
+# Pick which queue(s) to read and which entry types are eligible,
+# based on CLAUDE_ROLE. Order matters: orchestrator prefers PR pings
+# over generic deploy notifications.
+case "$ROLE" in
+    fixer)
+        QUEUES_ORDER="$QUEUE_ISSUES"
+        ALLOWED_TYPES="new_issue"
+        ;;
+    orchestrator)
+        QUEUES_ORDER="$QUEUE_ORCHESTRATOR $QUEUE_ISSUES"
+        # Orchestrator handles PR pings + generic deploy notifications.
+        # new_issue belongs to the fixer role — leave those untouched so
+        # the fixer session can consume them.
+        ALLOWED_TYPES="pr_ready,deploy,"
+        ;;
+    *)
+        QUEUES_ORDER="$QUEUE_ISSUES"
+        ALLOWED_TYPES="*"
+        ;;
+esac
+
+# Find the first unread entry across the chosen queues that matches
+# the role's allowed types, and atomically mark it read.
+FOUND=""
+for Q in $QUEUES_ORDER; do
+    [ -f "$Q" ] || continue
+    ENTRY=$(ALLOWED="$ALLOWED_TYPES" ROLE="$ROLE" python3 - "$Q" << 'PYEOF'
+import json, os, sys
+path = sys.argv[1]
+allowed = os.environ.get('ALLOWED', '*').split(',')
+role = os.environ.get('ROLE', '')
+allow_all = '*' in allowed
+
+with open(path) as f:
+    lines = f.readlines()
+
+for i, line in enumerate(lines):
+    line = line.rstrip('\n')
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+    except Exception:
+        continue
+    if obj.get('read'):
+        continue
+    # Respect explicit 'target' when the role is known.
+    target = obj.get('target')
+    if role and target and target != role:
+        continue
+    t = obj.get('type', '')
+    if not allow_all and t not in allowed:
+        continue
+    print(i)
+    print(json.dumps(obj))
+    break
+PYEOF
+)
+    if [ -n "$ENTRY" ]; then
+        LINE_NUM=$(echo "$ENTRY" | head -1)
+        PAYLOAD=$(echo "$ENTRY" | tail -1)
+        python3 - "$Q" "$LINE_NUM" << 'PYEOF'
+import json, sys
+path, lineno = sys.argv[1], int(sys.argv[2])
+with open(path) as f:
+    lines = f.readlines()
+lines[lineno] = json.dumps({**json.loads(lines[lineno]), 'read': True}) + '\n'
+with open(path, 'w') as f:
+    f.writelines(lines)
+PYEOF
+        FOUND="$PAYLOAD"
+        break
+    fi
+done
+
+if [ -z "$FOUND" ]; then
+    exit 0
+fi
+
+MESSAGE=$(echo "$FOUND" | python3 -c "import sys,json; print(json.load(sys.stdin).get('message',''))" 2>/dev/null)
+DETAILS=$(echo "$FOUND" | python3 -c "import sys,json; print(json.load(sys.stdin).get('details',''))" 2>/dev/null)
+NTYPE=$(echo "$FOUND" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type','deploy'))" 2>/dev/null)
+
+case "$NTYPE" in
+    new_issue)
+        CONTEXT="New autofix issue detected:
+
+$MESSAGE
+
+$DETAILS
+
+Before you do anything else: run \`scripts/autofix-claim.sh <issue-number>\` to acquire the cross-session lock. If it exits non-zero, another session is on it — stop. Otherwise proceed: read the issue, analyze the root cause, write a fix, run tests, and open a PR (body must include \`Fixes #<N>\`). Do NOT merge."
+        ;;
+    pr_ready)
+        CONTEXT="A PR opened by the autofix pipeline is waiting for review:
+
+$MESSAGE
+
+$DETAILS
+
+Surface this to the user so they can review and merge. Do not merge on their behalf."
+        ;;
+    *)
+        CONTEXT="Notification from deployment pipeline:
+
+$MESSAGE
+
+$DETAILS
+
+You can take action if appropriate (investigate failures, open issues)."
+        ;;
+esac
+
+HOOK_EVENT="$HOOK_EVENT" CONTEXT="$CONTEXT" python3 << 'PYEOF'
+import json, os
+context = os.environ.get('CONTEXT', '')
+event = os.environ.get('HOOK_EVENT', 'Stop')
+if event == 'Stop':
+    print(json.dumps({'decision': 'block', 'reason': context}))
+else:
+    print(json.dumps({
+        'hookSpecificOutput': {
+            'hookEventName': event,
+            'additionalContext': context
+        }
+    }))
+PYEOF
+
+# Only Stop should use exit 2. Others return 0 so user prompts / tool
+# calls are not rejected.
+if [ "$HOOK_EVENT" = "Stop" ]; then
+    exit 2
+fi
+exit 0


### PR DESCRIPTION
## Motivation
Today's #131 autofix flow worked end-to-end on the fixer side (notification → claim → branch → PR #132 opened in 4 minutes), then stalled **invisibly** at the review step: the fixer session went quiet after opening the PR, and there was no signal to the human-facing orchestrator session that a PR was waiting. The human only found PR #132 by asking "did anything happen?" manually.

Root cause: both sessions share one queue + one hook script that consumes whichever entry it finds first. There was no separation between "work the fixer should do" and "pings the orchestrator should surface to the human".

## What this adds
### 1. Dedicated PR-ready channel
\`.github/workflows/notify-pr-ready.yml\` fires on \`pull_request: opened\` (non-draft, also re-opens and ready-for-review) and writes a deduped entry to \`/opt/ai-hiring/notifications/orchestrator-queue.jsonl\`:
\`\`\`json
{"id":"pr-132","type":"pr_ready","target":"orchestrator","message":"📬 PR #132 ready for review: ..."}
\`\`\`

### 2. Role-aware hook script (canonical in-repo)
\`scripts/check-notifications.sh\` is now the canonical source for the live hook at \`/opt/ai-hiring/scripts/check-notifications.sh\`. It filters by \`CLAUDE_ROLE\`:

| Role | Reads | Consumes types |
|---|---|---|
| \`fixer\` | \`queue.jsonl\` | \`new_issue\` only |
| \`orchestrator\` | \`orchestrator-queue.jsonl\` then \`queue.jsonl\` | \`pr_ready\`, \`deploy\`, generic — **never** \`new_issue\` |
| unset (legacy) | \`queue.jsonl\` | any |

Two pre-existing bugs also fixed while refactoring:
- Previous script emitted \`exit 2\` on \`UserPromptSubmit\`, which GitHub/Claude interprets as "block this user prompt" — the root cause of the hook errors earlier today.
- Python heredoc had a stdin collision (\`<<< "\$CONTEXT"\` clashing with \`python3 -\` reading source from stdin); now passes context via env var.

### 3. Docs
\`CLAUDE.md\` gets a **Session roles** section plus the \`pr_ready\` mechanism.

## Required VPS setup (post-merge)
1. \`scp scripts/check-notifications.sh <vps>:/opt/ai-hiring/scripts/check-notifications.sh\`
2. Configure the **background fixer** session's environment with \`CLAUDE_ROLE=fixer\` (e.g., in its systemd unit or \`~/.bashrc\` for the user running it).
3. Interactive/orchestrator sessions set \`CLAUDE_ROLE=orchestrator\`; unset also works (falls back to legacy, but orchestrator is preferred).
4. \`mkdir -p /opt/ai-hiring/notifications\` — the workflow creates \`orchestrator-queue.jsonl\` on first use.

## Test plan
- [ ] Open a non-draft PR (any branch) → check \`orchestrator-queue.jsonl\` on VPS has a \`pr_ready\` entry.
- [ ] Re-open the same PR (or mark ready-for-review) → dedup prevents a second entry.
- [ ] Run the hook as \`CLAUDE_ROLE=fixer\` with a \`pr_ready\` in the orchestrator queue → skipped, orchestrator queue unchanged.
- [ ] Run the hook as \`CLAUDE_ROLE=orchestrator\` with only a \`new_issue\` in \`queue.jsonl\` → no-op, issue remains unread for the fixer.
- [ ] Locally sandboxed all four paths (fixer-consumes-issue / orchestrator-consumes-pr / orchestrator-skips-issue / empty-queue-exits-0) → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)