### PR TITLE
ci: staging failure pushes Discord + catches earlier-stage failures

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -343,21 +343,44 @@ jobs:
           path: e2e-tests/playwright-report/
 
   report-failure:
-    needs: [deploy, verify]
+    # Include earlier jobs so a build-and-push failure (e.g., the Gradle
+    # timeout on da531b7) also triggers this — previously the needs list
+    # only covered deploy/verify and such early failures were invisible
+    # to the report handler.
+    needs: [ci, build-and-push, deploy, verify]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
+      - name: Determine failed stage
+        id: stage
+        run: |
+          # Use job result inputs to name the first failing stage so the
+          # issue body and Discord ping are actionable.
+          if [ "${{ needs.ci.result }}" = "failure" ]; then
+            echo "stage=ci" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.build-and-push.result }}" = "failure" ]; then
+            echo "stage=build-and-push" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.deploy.result }}" = "failure" ]; then
+            echo "stage=deploy" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.verify.result }}" = "failure" ]; then
+            echo "stage=verify" >> "$GITHUB_OUTPUT"
+          else
+            echo "stage=unknown" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create failure issue
         uses: actions/github-script@v7
         with:
           script: |
             const sha = '${{ github.sha }}'.substring(0, 7);
+            const stage = '${{ steps.stage.outputs.stage }}';
             const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-            const title = `Staging deploy failed: commit ${sha}`;
+            const title = `Staging deploy failed at ${stage}: commit ${sha}`;
             const body = `## Deployment Failure\n\n` +
               `- **Environment**: staging\n` +
+              `- **Failed stage**: \`${stage}\`\n` +
               `- **Branch**: master\n` +
               `- **Commit**: \`${{ github.sha }}\`\n` +
               `- **Workflow run**: ${runUrl}\n\n` +
@@ -380,3 +403,36 @@ jobs:
               body: body,
               labels: ['bug', 'deployment']
             });
+
+      - name: Notify orchestrator (failure)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: SHA,STAGE,RUN_URL
+          script: |
+            python3 << 'PYEOF'
+            import json, datetime, os
+            sha = os.environ['SHA'][:7]
+            stage = os.environ['STAGE']
+            entry = {
+              'id': 'staging-fail-' + sha,
+              'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+              'read': False,
+              'type': 'deploy_fail',
+              'target': 'orchestrator',
+              'message': f"❌ Staging Deploy FAILED at {stage} — commit {sha}",
+              'details': f"Stage `{stage}` failed for staging deploy of {sha}. "
+                         f"An auto-issue has been filed with run logs.",
+              'run_url': os.environ.get('RUN_URL', '')
+            }
+            queue = '/opt/ai-hiring/notifications/orchestrator-queue.jsonl'
+            os.makedirs(os.path.dirname(queue), exist_ok=True)
+            with open(queue, 'a') as f:
+                f.write(json.dumps(entry) + '\n')
+            PYEOF
+        env:
+          SHA: ${{ github.sha }}
+          STAGE: ${{ steps.stage.outputs.stage }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Two bugs found when \`da531b7\` staging deploy failed

1. **Build-and-push failure wasn't signalled to Discord.** The staging deploy of \`da531b7\` failed at \`build-and-push\` (Gradle download timeout — transient, unrelated to PR #137). The \`report-failure\` job created issue #138 but nothing hit Discord. You only found out by asking "where's the staging success ping?"
2. **\`report-failure\` was scoped too narrowly.** It only \`needs: [deploy, verify]\`, so a failure in \`ci\` or \`build-and-push\` didn't register as \`failure()\` for this handler. It fired for \`da531b7\` only because the outer workflow was marked failed; earlier-stage failures could easily slip through silently.

## Fix
- \`report-failure.needs\` widened to \`[ci, build-and-push, deploy, verify]\` — any failing stage now triggers the handler.
- New \`Determine failed stage\` step computes the first failing stage name (ci / build-and-push / deploy / verify) from the \`needs.*.result\` inputs and exposes it as an output.
- GitHub issue title now includes the stage: \`Staging deploy failed at build-and-push: commit XXX\` (instead of just \`Staging deploy failed: commit XXX\`). Body adds a \`Failed stage\` line.
- New \`Notify orchestrator (failure)\` step writes \`type=deploy_fail\`, \`target=orchestrator\` to \`orchestrator-queue.jsonl\`. The Discord watcher picks it up the same way it handles deploy-success pings.

## Test plan
- [ ] The currently-re-running staging deploy for \`da531b7\` succeeds → verify the existing success path still works (and user gets Discord ping).
- [ ] Next time a transient failure happens (or simulate one) → Discord receives \`❌ Staging Deploy FAILED at <stage> — commit XXX\` within 5s.

## Related context
Companion to PR #137 which routed the success path to the orchestrator queue. This PR closes the mirrored gap on the failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)