### PR TITLE
fix: 相同简历能够被重复上传并显示

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/DuplicateResumeException.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/DuplicateResumeException.java
@@ -1,0 +1,18 @@
+package com.aihiring.resume;
+
+import com.aihiring.common.exception.BusinessException;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class DuplicateResumeException extends BusinessException {
+    private final UUID existingResumeId;
+    private final String existingFileName;
+
+    public DuplicateResumeException(UUID existingResumeId, String existingFileName) {
+        super(409, "Duplicate resume: identical file already exists");
+        this.existingResumeId = existingResumeId;
+        this.existingFileName = existingFileName;
+    }
+}

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/Resume.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/Resume.java
@@ -31,6 +31,9 @@ public class Resume extends BaseEntity {
     @Column(name = "raw_text", columnDefinition = "TEXT")
     private String rawText;
 
+    @Column(name = "file_hash", length = 64)
+    private String fileHash;
+
     @Enumerated(EnumType.STRING)
     @JdbcType(PostgreSQLEnumJdbcType.class)
     @Column(nullable = false)

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeController.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeController.java
@@ -71,6 +71,9 @@ public class ResumeController {
             try {
                 Resume resume = resumeService.uploadSingle(files[0], source, currentUser.getId());
                 return ResponseEntity.ok(ApiResponse.success(ResumeResponse.from(resume)));
+            } catch (DuplicateResumeException e) {
+                return ResponseEntity.status(409)
+                    .body(ApiResponse.error(409, e.getMessage()));
             } catch (BusinessException e) {
                 return ResponseEntity.badRequest()
                     .body(ApiResponse.error(400, e.getMessage()));
@@ -88,6 +91,9 @@ public class ResumeController {
             try {
                 Resume resume = resumeService.uploadSingle(file, source, currentUser.getId());
                 results.add(new BatchUploadResult(i, file.getOriginalFilename(), resume.getStatus().name(), resume.getId(), null));
+            } catch (DuplicateResumeException e) {
+                results.add(new BatchUploadResult(i, file.getOriginalFilename(), "DUPLICATE", e.getExistingResumeId(),
+                    "Duplicate of existing resume: " + e.getExistingFileName()));
             } catch (BusinessException e) {
                 results.add(new BatchUploadResult(i, file.getOriginalFilename(), "FAILED", null, e.getMessage()));
             } catch (Exception e) {

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeRepository.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeRepository.java
@@ -4,10 +4,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ResumeRepository extends JpaRepository<Resume, UUID> {
     Page<Resume> findBySource(ResumeSource source, Pageable pageable);
     Page<Resume> findByStatus(ResumeStatus status, Pageable pageable);
     Page<Resume> findBySourceAndStatus(ResumeSource source, ResumeStatus status, Pageable pageable);
+    Optional<Resume> findFirstByFileHash(String fileHash);
 }

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeService.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeService.java
@@ -20,6 +20,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -59,6 +62,12 @@ public class ResumeService {
         var user = userRepository.findById(uploadedByUserId)
             .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
+        byte[] fileBytes = file.getBytes();
+        String fileHash = sha256Hex(fileBytes);
+        resumeRepository.findFirstByFileHash(fileHash).ifPresent(existing -> {
+            throw new DuplicateResumeException(existing.getId(), existing.getFileName());
+        });
+
         String extension = TYPE_EXTENSIONS.get(file.getContentType());
         String storedName = UUID.randomUUID() + "." + extension;
         String storedPath = fileStorageService.store(file, storedName);
@@ -67,7 +76,7 @@ public class ResumeService {
         ResumeStatus status = ResumeStatus.UPLOADED;
         try {
             TextExtractor extractor = getExtractor(file.getContentType());
-            rawText = extractor.extract(new ByteArrayInputStream(file.getBytes()));
+            rawText = extractor.extract(new ByteArrayInputStream(fileBytes));
             status = ResumeStatus.TEXT_EXTRACTED;
         } catch (Exception e) {
             log.warn("Text extraction failed for file: {}. Saving with UPLOADED status.", file.getOriginalFilename(), e);
@@ -78,6 +87,7 @@ public class ResumeService {
         resume.setFilePath(storedPath);
         resume.setFileSize(file.getSize());
         resume.setFileType(file.getContentType());
+        resume.setFileHash(fileHash);
         resume.setRawText(rawText);
         resume.setSource(source);
         resume.setStatus(status);
@@ -86,6 +96,15 @@ public class ResumeService {
         resume = resumeRepository.save(resume);
         eventPublisher.publishEvent(new ResumeUploadedEvent(this, resume.getId(), rawText, file.getContentType()));
         return resume;
+    }
+
+    private static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(md.digest(data));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 
     @Transactional

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/dto/BatchUploadResponse.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/dto/BatchUploadResponse.java
@@ -9,6 +9,7 @@ public class BatchUploadResponse {
     private final int total;
     private final int succeeded;
     private final int failed;
+    private final int duplicated;
     private final List<BatchUploadResult> results;
 
     public BatchUploadResponse(List<BatchUploadResult> results) {
@@ -16,5 +17,6 @@ public class BatchUploadResponse {
         this.total = results.size();
         this.succeeded = (int) results.stream().filter(r -> r != null && ("UPLOADED".equals(r.getStatus()) || "TEXT_EXTRACTED".equals(r.getStatus()))).count();
         this.failed = (int) results.stream().filter(r -> r != null && "FAILED".equals(r.getStatus())).count();
+        this.duplicated = (int) results.stream().filter(r -> r != null && "DUPLICATE".equals(r.getStatus())).count();
     }
 }

--- a/ai-hiring-backend/src/main/resources/db/migration/V13__add_resume_file_hash.sql
+++ b/ai-hiring-backend/src/main/resources/db/migration/V13__add_resume_file_hash.sql
@@ -1,0 +1,2 @@
+ALTER TABLE resumes ADD COLUMN file_hash VARCHAR(64);
+CREATE INDEX idx_resumes_file_hash ON resumes(file_hash);

--- a/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeControllerIntegrationTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeControllerIntegrationTest.java
@@ -68,6 +68,42 @@ class ResumeControllerIntegrationTest {
     }
 
     @Test
+    void upload_sameFileTwice_secondShouldReturn409() throws Exception {
+        byte[] bytes = ("Duplicate Test " + UUID.randomUUID() + "\nContent").getBytes();
+        MockMultipartFile first = new MockMultipartFile("file", "dup-a.txt", "text/plain", bytes);
+        MockMultipartFile second = new MockMultipartFile("file", "dup-b.txt", "text/plain", bytes);
+
+        mockMvc.perform(multipart("/api/resumes/upload").file(first).with(adminUser()))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(multipart("/api/resumes/upload").file(second).with(adminUser()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(409));
+    }
+
+    @Test
+    void upload_batchWithDuplicate_shouldMarkAsDuplicate() throws Exception {
+        byte[] bytes = ("Batch Dup " + UUID.randomUUID() + "\nContent").getBytes();
+        MockMultipartFile seed = new MockMultipartFile("files", "seed.txt", "text/plain", bytes);
+        MockMultipartFile again = new MockMultipartFile("files", "again.txt", "text/plain", bytes);
+        MockMultipartFile fresh = new MockMultipartFile("files", "fresh.txt", "text/plain",
+            ("Fresh " + UUID.randomUUID()).getBytes());
+
+        // seed first
+        mockMvc.perform(multipart("/api/resumes/upload").file(seed).with(adminUser()))
+                .andExpect(status().isOk());
+
+        // batch with one duplicate and one new
+        mockMvc.perform(multipart("/api/resumes/upload")
+                .file(again)
+                .file(fresh)
+                .with(adminUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.duplicated").value(1))
+                .andExpect(jsonPath("$.data.results[?(@.fileName=='again.txt')].status").value("DUPLICATE"));
+    }
+
+    @Test
     void upload_withEmptyFile_shouldReturn400() throws Exception {
         MockMultipartFile file = new MockMultipartFile(
             "file", "empty.txt", "text/plain", new byte[0]

--- a/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeServiceTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeServiceTest.java
@@ -105,6 +105,47 @@ class ResumeServiceTest {
     }
 
     @Test
+    void uploadSingle_withDuplicateHash_shouldThrowDuplicateResumeException() throws IOException {
+        MockMultipartFile file = new MockMultipartFile("file", "resume.pdf", "application/pdf", "identical bytes".getBytes());
+        UUID userId = UUID.randomUUID();
+        User user = new User(); user.setId(userId);
+
+        UUID existingId = UUID.randomUUID();
+        Resume existing = new Resume();
+        existing.setId(existingId);
+        existing.setFileName("earlier.pdf");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(resumeRepository.findFirstByFileHash(any())).thenReturn(Optional.of(existing));
+
+        DuplicateResumeException ex = assertThrows(DuplicateResumeException.class,
+            () -> resumeService.uploadSingle(file, ResumeSource.MANUAL, userId));
+        assertEquals(existingId, ex.getExistingResumeId());
+        assertEquals("earlier.pdf", ex.getExistingFileName());
+        assertEquals(409, ex.getCode());
+        verify(resumeRepository, never()).save(any(Resume.class));
+        verify(fileStorageService, never()).store(any(), any());
+    }
+
+    @Test
+    void uploadSingle_shouldStoreFileHashOnResume() throws IOException {
+        MockMultipartFile file = new MockMultipartFile("file", "resume.pdf", "application/pdf", "pdf bytes".getBytes());
+        UUID userId = UUID.randomUUID();
+        User user = new User(); user.setId(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(resumeRepository.findFirstByFileHash(any())).thenReturn(Optional.empty());
+        when(fileStorageService.store(eq(file), any(String.class))).thenReturn("/uploads/resumes/uuid.pdf");
+        when(pdfTextExtractor.extract(any())).thenReturn("text");
+        when(resumeRepository.save(any(Resume.class))).thenAnswer(i -> { Resume r = i.getArgument(0); r.setId(UUID.randomUUID()); return r; });
+
+        Resume result = resumeService.uploadSingle(file, ResumeSource.MANUAL, userId);
+
+        assertNotNull(result.getFileHash());
+        assertEquals(64, result.getFileHash().length()); // SHA-256 hex
+    }
+
+    @Test
     void upload_withEmptyFile_shouldThrowBusinessException() {
         MockMultipartFile file = new MockMultipartFile("file", "resume.pdf", "application/pdf", new byte[0]);
         assertThrows(BusinessException.class, () -> resumeService.upload(file, ResumeSource.MANUAL, UUID.randomUUID()));

--- a/ai-hiring-backend/src/test/resources/schema-h2.sql
+++ b/ai-hiring-backend/src/test/resources/schema-h2.sql
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS resumes (
     experience CLOB,
     projects CLOB,
     skills CLOB,
+    file_hash VARCHAR(64),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -98,6 +99,7 @@ CREATE INDEX IF NOT EXISTS idx_resumes_source ON resumes(source);
 CREATE INDEX IF NOT EXISTS idx_resumes_status ON resumes(status);
 CREATE INDEX IF NOT EXISTS idx_resumes_uploaded_by ON resumes(uploaded_by);
 CREATE INDEX IF NOT EXISTS idx_resumes_created_at ON resumes(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_resumes_file_hash ON resumes(file_hash);
 
 -- Job Descriptions (H2-compatible: VARCHAR instead of enum, CLOB instead of JSONB)
 CREATE TABLE IF NOT EXISTS job_descriptions (

--- a/frontend/src/api/resumes.ts
+++ b/frontend/src/api/resumes.ts
@@ -69,6 +69,7 @@ export interface BatchUploadResponse {
   total: number;
   succeeded: number;
   failed: number;
+  duplicated: number;
   results: BatchUploadResult[];
 }
 

--- a/frontend/src/pages/resumes/BatchUploadModal.submit.test.tsx
+++ b/frontend/src/pages/resumes/BatchUploadModal.submit.test.tsx
@@ -20,7 +20,7 @@ describe('BatchUploadModal submit flow', () => {
 
   it('uploads multiple files and calls onSuccess', async () => {
     vi.mocked(resumesApi.uploadResumes).mockResolvedValueOnce({
-      total: 2, succeeded: 2, failed: 0,
+      total: 2, succeeded: 2, failed: 0, duplicated: 0,
       results: [
         { originalIndex: 0, fileName: 'a.pdf', status: 'TEXT_EXTRACTED', resumeId: 'r1', error: null },
         { originalIndex: 1, fileName: 'b.pdf', status: 'UPLOADED', resumeId: 'r2', error: null },

--- a/frontend/src/pages/resumes/BatchUploadModal.tsx
+++ b/frontend/src/pages/resumes/BatchUploadModal.tsx
@@ -13,7 +13,7 @@ interface BatchUploadModalProps {
 interface FileItem {
   uid: string;
   file: File;
-  status: 'pending' | 'uploading' | 'done' | 'error';
+  status: 'pending' | 'uploading' | 'done' | 'duplicate' | 'error';
   error?: string;
   result?: BatchUploadResponse['results'][number];
 }
@@ -54,15 +54,24 @@ export function BatchUploadModal({ open, onClose, onSuccess }: BatchUploadModalP
           const r = resultMap.get(f.file.name);
           if (!r) return { ...f, status: 'error' as const, error: 'No result returned' };
           const succeeded = r.status === 'UPLOADED' || r.status === 'TEXT_EXTRACTED';
+          const duplicate = r.status === 'DUPLICATE';
           return {
             ...f,
-            status: succeeded ? ('done' as const) : ('error' as const),
+            status: succeeded
+              ? ('done' as const)
+              : duplicate
+                ? ('duplicate' as const)
+                : ('error' as const),
             error: r.error ?? undefined,
             result: r,
           };
         })
       );
-      message.success(`Uploaded ${result.succeeded}/${result.total} resumes`);
+      const dupCount = result.duplicated ?? 0;
+      message.success(
+        `Uploaded ${result.succeeded}/${result.total} resumes` +
+          (dupCount > 0 ? ` (${dupCount} duplicate${dupCount > 1 ? 's' : ''} skipped)` : '')
+      );
       if (result.succeeded > 0) onSuccess();
     } catch (err) {
       message.error('Upload failed: ' + (err as Error).message);
@@ -126,6 +135,10 @@ export function BatchUploadModal({ open, onClose, onSuccess }: BatchUploadModalP
                 description={
                   item.status === 'error' ? (
                     <span style={{ color: 'red' }}>{item.error}</span>
+                  ) : item.status === 'duplicate' ? (
+                    <span style={{ color: 'orange' }}>
+                      {item.error ?? 'Duplicate (already exists)'}
+                    </span>
                   ) : item.status === 'done' ? (
                     <span style={{ color: 'green' }}>Uploaded</span>
                   ) : item.status === 'uploading' ? (


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #140: 相同简历能够被重复上传并显示

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/140

## Changes

- fix: detect duplicate resume uploads by file hash

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #140
issue: #140