### PR TITLE
fix: 简历下载失败

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeController.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -134,9 +136,22 @@ public class ResumeController {
         if (!resource.exists()) {
             return ResponseEntity.notFound().build();
         }
+        MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        String fileType = resume.getFileType();
+        if (fileType != null && !fileType.isBlank()) {
+            try {
+                mediaType = MediaType.parseMediaType(fileType);
+            } catch (org.springframework.http.InvalidMediaTypeException ignored) {
+                // fall back to octet-stream
+            }
+        }
+        String fileName = resume.getFileName() != null ? resume.getFileName() : "resume";
+        ContentDisposition disposition = ContentDisposition.attachment()
+            .filename(fileName, StandardCharsets.UTF_8)
+            .build();
         return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(resume.getFileType()))
-            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + resume.getFileName() + "\"")
+            .contentType(mediaType)
+            .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
             .body(resource);
     }
 

--- a/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeControllerIntegrationTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.aihiring.resume;
 
 import com.aihiring.common.security.UserDetailsImpl;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -313,6 +314,45 @@ class ResumeControllerIntegrationTest {
                 .andExpect(jsonPath("$.data.results[1].error").exists())
                 .andExpect(jsonPath("$.data.results[2].fileName").value("good2.txt"))
                 .andExpect(jsonPath("$.data.results[2].status").value("TEXT_EXTRACTED"));
+    }
+
+    @Test
+    void download_withAsciiFileName_shouldReturnFileContent() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "download-ascii.txt", "text/plain", "download me".getBytes()
+        );
+        MvcResult uploadResult = mockMvc.perform(multipart("/api/resumes/upload")
+                .file(file)
+                .with(adminUser()))
+                .andReturn();
+        String responseBody = uploadResult.getResponse().getContentAsString();
+        String id = responseBody.split("\"id\":\"")[1].split("\"")[0];
+
+        mockMvc.perform(get("/api/resumes/" + id + "/download")
+                .with(adminUser()))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
+                    org.hamcrest.Matchers.containsString("download-ascii.txt")));
+    }
+
+    @Test
+    void download_withChineseFileName_shouldReturn200AndEncodedHeader() throws Exception {
+        // Chinese filename must not break Content-Disposition header (Tomcat rejects non-ISO-8859-1)
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "张三简历.txt", "text/plain", "简历内容 download me".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        );
+        MvcResult uploadResult = mockMvc.perform(multipart("/api/resumes/upload")
+                .file(file)
+                .with(adminUser()))
+                .andReturn();
+        String responseBody = uploadResult.getResponse().getContentAsString();
+        String id = responseBody.split("\"id\":\"")[1].split("\"")[0];
+
+        mockMvc.perform(get("/api/resumes/" + id + "/download")
+                .with(adminUser()))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
+                    org.hamcrest.Matchers.containsString("filename*=UTF-8''")));
     }
 
     @Test


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #143: 简历下载失败

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/143

## Changes

- fix: properly encode non-ASCII resume filenames in download header

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #143
issue: #143