### PR TITLE
ci: smoke uses unique payload + smoke failure fails the job

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -131,8 +131,11 @@ jobs:
           fi
 
           # 2. Resume upload
+          #    Must produce a unique payload each run — since PR #142
+          #    landed a SHA-256 file-hash dedup, a constant test payload
+          #    gets rejected with HTTP 409 from the second deploy onward.
           if [ -n "$TOKEN" ]; then
-            echo "smoke test resume" > /tmp/smoke.txt
+            echo "smoke test resume ${GITHUB_RUN_ID} ${GITHUB_SHA} $(date +%s%N)" > /tmp/smoke.txt
             UPLOAD=$(curl -sf -X POST "$BASE/api/resumes/upload" \
               -H "Authorization: Bearer $TOKEN" \
               -F "file=@/tmp/smoke.txt;type=text/plain" || echo '{}')
@@ -286,6 +289,18 @@ jobs:
           SHA: ${{ github.sha }}
           DETAILS: ${{ steps.smoke.outputs.details }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Fail the job if any smoke check failed
+        # Placed AFTER the orchestrator-notify step so Discord still
+        # receives the failure ping. Without this, smoke setting
+        # PASS=false would still leave the verify job green — the GH
+        # Actions UI misreported success and report-failure never ran
+        # even though Discord knew the truth. Propagating here keeps
+        # the UI and the notifier in sync and gates e2e + report-failure.
+        if: steps.smoke.outputs.pass != 'true'
+        run: |
+          echo "::error::Staging smoke test failed — see 'Smoke test staging' step for details"
+          exit 1
 
       - name: Trigger Verifier Agent on VPS
         if: steps.smoke.outputs.pass == 'true' && steps.linked.outputs.issues != ''


### PR DESCRIPTION
## Two bugs exposed by the \`a1aa864\` staging deploy

### 1. Constant smoke payload vs new dedup
Our smoke test did:
\`\`\`bash
echo "smoke test resume" > /tmp/smoke.txt
curl -F "file=@/tmp/smoke.txt"
\`\`\`
That 17-byte payload is byte-identical every run. Before PR #142 the backend happily accepted it as a new upload. PR #142 added SHA-256 file-hash dedup, so the first deploy after PR #142 (\`b380404\`) uploaded fine and the second (\`a1aa864\`) got \`HTTP 409 Duplicate resume\` — smoke flipped to \`PASS=false\`.

This is actually **proof that PR #142's dedup works in staging**; the smoke test just got stuck on the old assumption.

Fix: make the payload unique per run.
\`\`\`bash
echo "smoke test resume ${GITHUB_RUN_ID} ${GITHUB_SHA} $(date +%s%N)" > /tmp/smoke.txt
\`\`\`
Nanosecond timestamp is belt-and-braces in case a workflow is re-run with the same RUN_ID + SHA.

### 2. Smoke failure didn't fail the job
Even with \`PASS=false\`, the smoke shell exited 0, so:
- \`verify\` job conclusion = \`success\` ✅ (wrong)
- \`report-failure\` job \`if: failure()\` → skipped (wrong)
- But our \`Notify orchestrator on VPS\` step correctly wrote \`type=deploy_fail\` (right)

→ Discord said fail, GH UI said success. The two disagreed, and a human who didn't check Discord would think deploys were fine.

Fix: new step \`Fail the job if any smoke check failed\` with \`if: steps.smoke.outputs.pass != 'true'\` → \`exit 1\`, placed AFTER \`Notify orchestrator on VPS\` so the Discord ping still fires on failure.

## Step ordering
New position of \`Fail the job…\`:
\`\`\`
Smoke test staging
Resolve linked issues
Comment on linked issues
Notify orchestrator on VPS        ← Discord failure ping still fires
Fail the job if any smoke failed  ← NEW, fails the job
Trigger Verifier Agent on VPS     ← already gated on pass=='true'
\`\`\`

## Test plan
- [ ] Merge → staging redeploys → smoke passes with unique payload → Discord receives \`✅ Staging Deploy Complete\`.
- [ ] Manually break a smoke assertion in a throwaway PR → Discord receives \`❌ Staging Deploy FAILED\` AND the GH workflow shows \`failure\` AND the \`Staging deploy failed: commit X\` issue is auto-created.

## Residual
Other smoke checks (Departments list, Jobs list) don't mutate state — they're safe against future backend changes. Only the Resume upload step has this problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)