### PR TITLE
fix: persist resume uploads across container recreates (issue #143)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -130,21 +130,39 @@ jobs:
             echo "DEBUG permissions: $ME_PERMS"
           fi
 
-          # 2. Resume upload
-          #    Must produce a unique payload each run — since PR #142
-          #    landed a SHA-256 file-hash dedup, a constant test payload
-          #    gets rejected with HTTP 409 from the second deploy onward.
+          # 2. Resume upload + download round-trip.
+          #    Unique payload per run because PR #142 landed SHA-256
+          #    file-hash dedup. Follow-up download check guards against
+          #    the class of bug in issue #143 where uploads worked but
+          #    the saved file was lost on next redeploy (no persistent
+          #    volume mount), so /resumes/{id}/download returned 404.
           if [ -n "$TOKEN" ]; then
             echo "smoke test resume ${GITHUB_RUN_ID} ${GITHUB_SHA} $(date +%s%N)" > /tmp/smoke.txt
             UPLOAD=$(curl -sf -X POST "$BASE/api/resumes/upload" \
               -H "Authorization: Bearer $TOKEN" \
               -F "file=@/tmp/smoke.txt;type=text/plain" || echo '{}')
             CODE=$(echo "$UPLOAD" | python3 -c "import sys,json; print(json.load(sys.stdin).get('code',''))" 2>/dev/null)
+            RESUME_ID=$(echo "$UPLOAD" | python3 -c "import sys,json; d=json.load(sys.stdin).get('data') or {}; print(d.get('id',''))" 2>/dev/null)
             if [ "$CODE" = "200" ]; then
               DETAILS="${DETAILS}\n- ✅ Resume upload"
             else
               PASS=false
               DETAILS="${DETAILS}\n- ❌ Resume upload (response: $CODE)"
+            fi
+
+            # Download the just-uploaded resume to verify file storage is
+            # actually persistent end-to-end.
+            if [ -n "$RESUME_ID" ]; then
+              DL_HTTP=$(curl -s -o /tmp/smoke-dl.bin -w "%{http_code}" \
+                "$BASE/api/resumes/${RESUME_ID}/download" \
+                -H "Authorization: Bearer $TOKEN")
+              DL_SIZE=$(wc -c < /tmp/smoke-dl.bin 2>/dev/null || echo 0)
+              if [ "$DL_HTTP" = "200" ] && [ "$DL_SIZE" -gt 0 ]; then
+                DETAILS="${DETAILS}\n- ✅ Resume download (${DL_SIZE} bytes)"
+              else
+                PASS=false
+                DETAILS="${DETAILS}\n- ❌ Resume download (HTTP=$DL_HTTP, size=$DL_SIZE)"
+              fi
             fi
           fi
 

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -28,6 +28,10 @@ services:
     depends_on:
       - ai-matching
     restart: unless-stopped
+    # Persist uploaded resume files — mirrors the fix for issue #143 in
+    # staging/prod so dev behaves the same way.
+    volumes:
+      - dev-resume-uploads:/app/uploads
     networks:
       - dev-internal
       - ai-hiring-network
@@ -52,3 +56,6 @@ networks:
   dev-internal:
   ai-hiring-network:
     external: true
+
+volumes:
+  dev-resume-uploads:

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -29,6 +29,11 @@ services:
     depends_on:
       - ai-matching
     restart: always
+    # Persist uploaded resume files across container recreates — without
+    # a volume here, every redeploy wipes /app/uploads and download
+    # endpoints return 404 for all pre-existing resumes (issue #143).
+    volumes:
+      - prod-resume-uploads:/app/uploads
     networks:
       - prod-internal
       - ai-hiring-network
@@ -54,3 +59,6 @@ networks:
   prod-internal:
   ai-hiring-network:
     external: true
+
+volumes:
+  prod-resume-uploads:

--- a/docker/staging/docker-compose.yml
+++ b/docker/staging/docker-compose.yml
@@ -27,6 +27,12 @@ services:
     depends_on:
       - ai-matching
     restart: unless-stopped
+    # Persist uploaded resume files across container recreates.
+    # Without this, every redeploy wipes /app/uploads and the resume
+    # rows in Postgres point at files that no longer exist — the
+    # /resumes/{id}/download endpoint then 404s (observed in issue #143).
+    volumes:
+      - staging-resume-uploads:/app/uploads
     networks:
       - staging-internal
       - ai-hiring-network
@@ -51,3 +57,6 @@ networks:
   staging-internal:
   ai-hiring-network:
     external: true
+
+volumes:
+  staging-resume-uploads:


### PR DESCRIPTION
Fixes #143 (for real this time).

## Why PR #144 didn't fix #143
PR #144 changed how non-ASCII filenames are encoded in the \`Content-Disposition\` header. Issue #143's real symptom is \"Download Error\" in the UI because the download endpoint returns **HTTP 404 with Content-Length 0** — regardless of filename. Encoding was never the problem.

## Actual root cause
Reproduction on staging just now:
\`\`\`bash
GET /api/resumes/bee230bd-.../download
→ HTTP 404, Content-Length: 0
\`\`\`

Tracing:
\`\`\`java
Resource resource = fileStorageService.load(resume.getFilePath());
if (!resource.exists()) {
    return ResponseEntity.notFound().build();    // ← this line
}
\`\`\`

So the DB row exists, the path is readable, but the file at that path is gone. Looking at the container:
\`\`\`bash
$ docker inspect staging-backend-1 --format '{{json .Mounts}}'
[]

$ docker exec staging-backend-1 ls /app/uploads/resumes/
aa723d91-...-a75915215c96.txt          # <-- only the most-recent smoke upload
\`\`\`

**No volume mounts.** \`/app/uploads\` lives entirely inside the container's ephemeral filesystem. Every \`docker compose down && up -d\` (which is what \`scripts/deploy.sh\` does, per CLAUDE.md) destroys and recreates the container — all files in \`/app/uploads\` gone. DB rows are preserved (Postgres has its own volume), so the schema/DB appears fine but the files are orphaned.

This has been broken since day one; nobody noticed because smoke tests only uploaded, never downloaded.

## Fix
1. Add a named Docker volume \`<env>-resume-uploads\` to \`docker/{dev,staging,prod}/docker-compose.yml\`, mounted at \`/app/uploads\`. Named volume (not bind mount) so Docker manages UID 100:101 permissions automatically. Survives container recreates.
2. Smoke test now performs an upload + download round-trip. Any future regression in file persistence will fail staging deploy (and fire Discord via PR #141's notification path).

## Caveat: existing orphan rows
Resume rows already in any env's DB reference files that are already gone. After this PR merges + deploys, those rows will still 404 on download. Only **new uploads from now on** will survive redeploys. A follow-up cleanup could delete orphan rows, but that's data-loss — leaving it to the operator's discretion.

## Test plan
- [x] Reproduced the 404 against staging to confirm root cause.
- [x] \`yaml.safe_load\` on all three compose files.
- [ ] On merge → staging redeploys → smoke asserts 200 on download round-trip → Discord confirms.
- [ ] After merge, upload a fresh resume via staging UI → then force a redeploy (e.g. trigger Deploy Staging manually) → download that resume → file persists.
- [ ] Repeat for prod after \`deploy-prod.yml\` is triggered with this SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)