### PR TITLE
fix: Production AI Matching returns no candidates from Web UI despite processed resumes

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/matching/AiMatchingClient.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/matching/AiMatchingClient.java
@@ -42,6 +42,19 @@ public class AiMatchingClient {
         }
     }
 
+    public boolean deleteResumeVector(UUID resumeId) {
+        try {
+            restClient.delete()
+                .uri("/internal/vectorize/resume/{id}", resumeId)
+                .retrieve()
+                .toBodilessEntity();
+            return true;
+        } catch (RestClientException e) {
+            log.warn("Failed to delete resume vector {}: {}", resumeId, e.getMessage());
+            return false;
+        }
+    }
+
     public boolean vectorizeJob(UUID jobId, String title, String description,
                               String requirements, String skills) {
         try {

--- a/ai-hiring-backend/src/main/java/com/aihiring/matching/AiMatchingEventListener.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/matching/AiMatchingEventListener.java
@@ -1,6 +1,7 @@
 package com.aihiring.matching;
 
 import com.aihiring.job.JobDescriptionSavedEvent;
+import com.aihiring.resume.ResumeDeletedEvent;
 import com.aihiring.resume.ResumeRepository;
 import com.aihiring.resume.ResumeStatus;
 import com.aihiring.resume.ResumeUploadedEvent;
@@ -50,6 +51,20 @@ public class AiMatchingEventListener {
             });
         } catch (Throwable t) {
             log.error("Failed to update resume {} status to {}", resumeId, target, t);
+        }
+    }
+
+    @Async
+    @EventListener
+    public void onResumeDeleted(ResumeDeletedEvent event) {
+        // Prevent orphan vectors: when a resume is deleted from the DB,
+        // remove its Qdrant vector too. Otherwise stale vectors accumulate
+        // and can crowd out live resumes in similarity search results.
+        log.info("Deleting resume vector {}", event.getResumeId());
+        try {
+            client.deleteResumeVector(event.getResumeId());
+        } catch (Throwable t) {
+            log.error("Unexpected error deleting resume vector {}", event.getResumeId(), t);
         }
     }
 

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeDeletedEvent.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeDeletedEvent.java
@@ -1,0 +1,16 @@
+package com.aihiring.resume;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.UUID;
+
+@Getter
+public class ResumeDeletedEvent extends ApplicationEvent {
+    private final UUID resumeId;
+
+    public ResumeDeletedEvent(Object source, UUID resumeId) {
+        super(source);
+        this.resumeId = resumeId;
+    }
+}

--- a/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeService.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/resume/ResumeService.java
@@ -138,6 +138,7 @@ public class ResumeService {
         Resume resume = getById(id);
         fileStorageService.delete(resume.getFilePath());
         resumeRepository.delete(resume);
+        eventPublisher.publishEvent(new ResumeDeletedEvent(this, id));
     }
 
     @Transactional

--- a/ai-hiring-backend/src/test/java/com/aihiring/matching/AiMatchingClientTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/matching/AiMatchingClientTest.java
@@ -82,6 +82,31 @@ class AiMatchingClientTest {
     }
 
     @Test
+    void deleteResumeVector_success_returnsTrue() {
+        UUID resumeId = UUID.randomUUID();
+        wm.stubFor(delete(urlEqualTo("/internal/vectorize/resume/" + resumeId))
+            .willReturn(aResponse().withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"status\":\"ok\"}")));
+
+        boolean result = client.deleteResumeVector(resumeId);
+
+        assertThat(result).isTrue();
+        wm.verify(deleteRequestedFor(urlEqualTo("/internal/vectorize/resume/" + resumeId)));
+    }
+
+    @Test
+    void deleteResumeVector_serviceError_returnsFalse() {
+        UUID resumeId = UUID.randomUUID();
+        wm.stubFor(delete(urlEqualTo("/internal/vectorize/resume/" + resumeId))
+            .willReturn(aResponse().withStatus(500)));
+
+        boolean result = client.deleteResumeVector(resumeId);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
     void match_returnsDeserializedResponse() {
         UUID jobId = UUID.randomUUID();
         wm.stubFor(post(urlEqualTo("/match"))

--- a/ai-hiring-backend/src/test/java/com/aihiring/matching/AiMatchingEventListenerTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/matching/AiMatchingEventListenerTest.java
@@ -2,6 +2,7 @@ package com.aihiring.matching;
 
 import com.aihiring.job.JobDescriptionSavedEvent;
 import com.aihiring.resume.Resume;
+import com.aihiring.resume.ResumeDeletedEvent;
 import com.aihiring.resume.ResumeRepository;
 import com.aihiring.resume.ResumeStatus;
 import com.aihiring.resume.ResumeUploadedEvent;
@@ -99,6 +100,27 @@ class AiMatchingEventListenerTest {
 
         assertThat(resume.getStatus()).isEqualTo(ResumeStatus.VECTORIZATION_FAILED);
         verify(resumeRepository).save(resume);
+    }
+
+    @Test
+    void onResumeDeleted_callsDeleteResumeVector() {
+        UUID resumeId = UUID.randomUUID();
+        var event = new ResumeDeletedEvent(this, resumeId);
+
+        listener.onResumeDeleted(event);
+
+        verify(client).deleteResumeVector(resumeId);
+    }
+
+    @Test
+    void onResumeDeleted_clientThrows_doesNotPropagate() {
+        UUID resumeId = UUID.randomUUID();
+        var event = new ResumeDeletedEvent(this, resumeId);
+        when(client.deleteResumeVector(resumeId)).thenThrow(new RuntimeException("boom"));
+
+        listener.onResumeDeleted(event);
+
+        verify(client).deleteResumeVector(resumeId);
     }
 
     @Test

--- a/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeServiceTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/resume/ResumeServiceTest.java
@@ -201,6 +201,20 @@ class ResumeServiceTest {
     }
 
     @Test
+    void delete_shouldPublishResumeDeletedEvent() {
+        UUID id = UUID.randomUUID();
+        Resume resume = new Resume(); resume.setId(id); resume.setFilePath("/uploads/resumes/uuid.pdf");
+        when(resumeRepository.findById(id)).thenReturn(Optional.of(resume));
+
+        resumeService.delete(id);
+
+        org.mockito.ArgumentCaptor<ResumeDeletedEvent> captor =
+            org.mockito.ArgumentCaptor.forClass(ResumeDeletedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertEquals(id, captor.getValue().getResumeId());
+    }
+
+    @Test
     void updateStructured_shouldUpdateFieldsAndSetAiProcessed() {
         UUID id = UUID.randomUUID();
         Resume resume = new Resume(); resume.setId(id); resume.setStatus(ResumeStatus.TEXT_EXTRACTED);

--- a/ai-matching-service/routers/vectorize.py
+++ b/ai-matching-service/routers/vectorize.py
@@ -15,6 +15,12 @@ async def vectorize_resume(request: VectorizeResumeRequest):
     return VectorizeResponse(status="ok")
 
 
+@router.delete("/resume/{resume_id}", response_model=VectorizeResponse, response_model_exclude_none=True)
+async def delete_resume_vector(resume_id: str):
+    await vector_store.delete_resume(resume_id)
+    return VectorizeResponse(status="ok")
+
+
 @router.post("/job", response_model=VectorizeResponse, response_model_exclude_none=True)
 async def vectorize_job(request: VectorizeJobRequest):
     job_text = f"Title: {request.title}\n\nDescription:\n{request.description}"

--- a/ai-matching-service/services/vector_store.py
+++ b/ai-matching-service/services/vector_store.py
@@ -1,5 +1,5 @@
 from qdrant_client import AsyncQdrantClient
-from qdrant_client.models import Distance, VectorParams, PointStruct
+from qdrant_client.models import Distance, VectorParams, PointStruct, PointIdsList
 from config import settings
 
 client = AsyncQdrantClient(host=settings.qdrant_host, port=settings.qdrant_port)
@@ -62,6 +62,13 @@ async def get_job_record(job_id: str):
         collection_name=JOBS, ids=[job_id], with_vectors=True
     )
     return results[0] if results else None
+
+
+async def delete_resume(resume_id: str):
+    await client.delete(
+        collection_name=RESUMES,
+        points_selector=PointIdsList(points=[resume_id]),
+    )
 
 
 async def search_resumes(job_vector: list[float], top_k: int):

--- a/ai-matching-service/tests/test_vector_store.py
+++ b/ai-matching-service/tests/test_vector_store.py
@@ -100,6 +100,20 @@ async def test_get_job_vector_returns_none_when_not_found():
 
 
 @pytest.mark.asyncio
+async def test_delete_resume_removes_point_from_collection():
+    """Regression for issue #147: orphan Qdrant vectors for deleted resumes
+    poison match results because MatchController filters them out post-search,
+    sometimes leaving no live candidates. Deleting the vector on resume delete
+    prevents the orphan from accumulating."""
+    await vs.delete_resume("resume-789")
+
+    vs.client.delete.assert_called_once()
+    call_kwargs = vs.client.delete.call_args.kwargs
+    assert call_kwargs["collection_name"] == "resumes"
+    assert call_kwargs["points_selector"].points == ["resume-789"]
+
+
+@pytest.mark.asyncio
 async def test_search_resumes_returns_scored_points():
     mock_point = MagicMock()
     mock_point.id = "resume-123"

--- a/ai-matching-service/tests/test_vectorize.py
+++ b/ai-matching-service/tests/test_vectorize.py
@@ -75,6 +75,29 @@ def test_vectorize_job_constructs_text_with_all_fields(client):
     assert "Python" in embedded_text
 
 
+def test_delete_resume_vector_calls_vector_store(client):
+    """Regression for issue #147: resume deletion must remove its Qdrant vector
+    so stale vectors don't poison match results."""
+    delete_mock = AsyncMock()
+    with patch("services.vector_store.delete_resume", new=delete_mock):
+        response = client.delete(
+            "/internal/vectorize/resume/550e8400-e29b-41d4-a716-446655440002"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    delete_mock.assert_called_once_with("550e8400-e29b-41d4-a716-446655440002")
+
+
+def test_delete_resume_vector_is_idempotent(client):
+    """Deleting a non-existent vector is not an error — Qdrant delete is a no-op."""
+    with patch("services.vector_store.delete_resume", new=AsyncMock()):
+        response = client.delete(
+            "/internal/vectorize/resume/550e8400-e29b-41d4-a716-446655440003"
+        )
+    assert response.status_code == 200
+
+
 def test_vectorize_job_upsert_is_idempotent(client):
     """Re-vectorizing the same ID overwrites — upsert is called each time."""
     upsert_mock = AsyncMock()


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #147: Production AI Matching returns no candidates from Web UI despite processed resumes

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/147

## Changes

- fix: delete Qdrant vector when resume is deleted (issue #147)

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #147
issue: #147