### PR TITLE
ci: reopened issues re-enter the autofix pipeline

### DIFF
--- a/.github/workflows/notify-new-issue.yml
+++ b/.github/workflows/notify-new-issue.yml
@@ -2,12 +2,14 @@ name: Notify Autofix Issue
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, reopened]
 
 jobs:
   notify:
     if: contains(github.event.issue.labels.*.name, 'autofix')
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Write to VPS notification queue
         uses: appleboy/ssh-action@v1
@@ -15,40 +17,61 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          envs: ISSUE_NUMBER,ISSUE_TITLE,ISSUE_LABELS,ISSUE_URL,ISSUE_BODY
+          envs: ISSUE_NUMBER,ISSUE_TITLE,ISSUE_LABELS,ISSUE_URL,ISSUE_BODY,EVENT_ACTION
           script: |
             python3 << 'PYEOF'
             import json, datetime, os
             queue_path = '/opt/ai-hiring/notifications/queue.jsonl'
-            entry_id = f'issue-{os.environ["ISSUE_NUMBER"]}'
+            processed_file = '/opt/ai-hiring/processed-issues.txt'
+            issue_num = os.environ['ISSUE_NUMBER']
+            action = os.environ.get('EVENT_ACTION', 'opened')
 
-            # Dedup: GitHub fires both `opened` and one `labeled` event per label
-            # added by issue-triage.yml, so this workflow runs multiple times per
-            # issue. Skip if the queue already contains an entry with this id.
-            try:
-                with open(queue_path) as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            if json.loads(line).get('id') == entry_id:
-                                print(f'Skip duplicate notification for {entry_id}')
-                                raise SystemExit(0)
-                        except json.JSONDecodeError:
-                            continue
-            except FileNotFoundError:
-                pass
+            # `reopened` must bypass the normal 'issue-<N>' dedup (the
+            # first open of the same issue wrote one already) AND also
+            # un-dedupe the watch-issues cron side: drop the issue number
+            # from processed-issues.txt so the next cron cycle will
+            # redispatch. Without this, reopening an issue was a no-op —
+            # both the queue writer and the cron dedup kept swallowing it.
+            if action == 'reopened':
+                entry_id = f'issue-{issue_num}-reopen-{datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")}'
+                try:
+                    with open(processed_file) as f:
+                        kept = [l for l in f if l.strip() and l.strip() != issue_num]
+                    with open(processed_file, 'w') as f:
+                        f.writelines(kept)
+                    print(f'Removed #{issue_num} from processed-issues.txt')
+                except FileNotFoundError:
+                    pass
+            else:
+                entry_id = f'issue-{issue_num}'
+                # Dedup only for opened/labeled bursts (triage adds several
+                # labels in quick succession → multiple workflow runs).
+                try:
+                    with open(queue_path) as f:
+                        for line in f:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                if json.loads(line).get('id') == entry_id:
+                                    print(f'Skip duplicate notification for {entry_id}')
+                                    raise SystemExit(0)
+                            except json.JSONDecodeError:
+                                continue
+                except FileNotFoundError:
+                    pass
 
+            prefix = '🔁 Autofix re-opened' if action == 'reopened' else '🔧 Autofix issue'
             entry = {
               'id': entry_id,
               'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
               'read': False,
               'type': 'new_issue',
-              'message': f'🔧 Autofix issue #{os.environ["ISSUE_NUMBER"]}: {os.environ["ISSUE_TITLE"]}',
-              'details': f'Labels: {os.environ.get("ISSUE_LABELS","")}\nURL: {os.environ["ISSUE_URL"]}\n\n{os.environ.get("ISSUE_BODY","")[:500]}',
+              'message': f'{prefix} #{issue_num}: {os.environ["ISSUE_TITLE"]}',
+              'details': f'Event: {action}\nLabels: {os.environ.get("ISSUE_LABELS","")}\nURL: {os.environ["ISSUE_URL"]}\n\n{os.environ.get("ISSUE_BODY","")[:500]}',
               'run_url': os.environ["ISSUE_URL"]
             }
+            os.makedirs(os.path.dirname(queue_path), exist_ok=True)
             with open(queue_path, 'a') as f:
                 f.write(json.dumps(entry) + '\n')
             PYEOF
@@ -58,3 +81,17 @@ jobs:
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          EVENT_ACTION: ${{ github.event.action }}
+
+      - name: Release stale autofix-in-progress label on reopen
+        # A prior failed autofix may have left the advisory lock behind.
+        # Reopening the issue is the user's explicit "try again" signal,
+        # so clear the lock unconditionally here. autofix-claim.sh on the
+        # VPS will re-acquire it before the fixer actually starts.
+        if: github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, 'autofix-in-progress')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label 'autofix-in-progress' || true


### PR DESCRIPTION
Fixes the silent-no-op behavior on re-opened issues, reproduced just now with issue #147.

## Repro
1. Fixer successfully closes issue via auto-closing PR → issue CLOSED, \`autofix-in-progress\` label removed on issue closure, issue number remains in \`/opt/ai-hiring/processed-issues.txt\`.
2. User verifies on prod, problem is NOT actually fixed, clicks **Reopen** on the issue.
3. **Nothing happens.** No queue entry, no Discord, no fixer dispatch.

## Root causes (three layers of dedup all blocking the retry)
1. \`.github/workflows/notify-new-issue.yml\` trigger types: \`[opened, labeled]\` — no \`reopened\`, so the workflow never fires.
2. \`/opt/ai-hiring/scripts/watch-issues.sh\` (cron every 2 min) dedupes via \`processed-issues.txt\`, which is append-only. Once an issue is in there it's skipped forever.
3. \`.github/workflows/notify-new-issue.yml\` itself also dedupes by \`issue-<N>\` id in \`queue.jsonl\` — even if trigger types were fixed, the reopened event would land on the same id and be swallowed.

## Changes
- Add \`reopened\` to the workflow trigger types.
- On \`reopened\`:
  - Use a timestamped entry id (\`issue-147-reopen-20260424071344\`) so the queue-dedup block doesn't suppress the retry.
  - Remove the issue number from \`processed-issues.txt\` so \`watch-issues.sh\` cron also redispatches.
- New step \`Release stale autofix-in-progress label on reopen\`: if the label is present (leftover from a failed prior attempt), drop it. \`autofix-claim.sh\` will re-acquire it when the fixer actually starts, so no race.
- Message prefix changes from \`🔧 Autofix issue\` to \`🔁 Autofix re-opened\` on retries so it's visually distinct in Discord and in the VPS queue log.

## Test plan
- [ ] Close then reopen a test issue with the \`autofix\` label → \`notify-new-issue.yml\` fires with action=reopened → new timestamped entry in \`queue.jsonl\` → \`processed-issues.txt\` entry removed → cron OR manual dispatch picks it up → fixer opens a new PR → Discord pings with 🔁 prefix.
- [x] Manually verified #147 retry works when the three dedup layers are cleared by hand (this PR automates that).
- [ ] Negative test: normal \`opened\` event still dedupes labeled-burst multi-fires as before (existing behavior unchanged).

## Out of scope
- Retry policy for **failed** autofix attempts (max-turns exhausted, Claude couldn't determine fix). Currently user must manually re-label or close-and-reopen. An escalating-MAX_TURNS auto-retry would be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)