### PR TITLE
fix: Production AI Matching returns no candidates from Web UI despite processed resumes

### DIFF
--- a/ai-hiring-backend/src/main/java/com/aihiring/matching/MatchController.java
+++ b/ai-hiring-backend/src/main/java/com/aihiring/matching/MatchController.java
@@ -24,12 +24,23 @@ public class MatchController {
     private final MatchService matchService;
     private final ResumeRepository resumeRepository;
 
+    // Over-fetch candidates from AI service so orphan-vector filtering (resumes present
+    // in Qdrant but no longer in DB) still leaves enough live matches to fill top_k.
+    // See issue #147.
+    static final int ORPHAN_OVERFETCH_MULTIPLIER = 3;
+    static final int ORPHAN_OVERFETCH_CAP = 50;
+
     @PostMapping
     @PreAuthorize("hasAuthority('job:read')")
     public ApiResponse<MatchResponse> match(@Valid @RequestBody MatchRequest request) {
+        int requestedTopK = request.getTopK();
+        int fetchTopK = Math.min(requestedTopK * ORPHAN_OVERFETCH_MULTIPLIER, ORPHAN_OVERFETCH_CAP);
+        if (fetchTopK < requestedTopK) {
+            fetchTopK = requestedTopK;
+        }
         AiMatchResponse aiResponse;
         try {
-            aiResponse = matchService.match(request.getJobId(), request.getTopK());
+            aiResponse = matchService.match(request.getJobId(), fetchTopK);
         } catch (HttpClientErrorException.NotFound e) {
             throw new BusinessException(422, "Job not ready for matching, please try again shortly");
         } catch (ResourceAccessException e) {
@@ -77,6 +88,7 @@ public class MatchController {
                 item.getVectorScore(), item.getLlmScore(),
                 item.getReasoning(), item.getHighlights()
             ))
+            .limit(requestedTopK)
             .collect(Collectors.toList());
 
         return ApiResponse.success(new MatchResponse(

--- a/ai-hiring-backend/src/test/java/com/aihiring/matching/MatchControllerIntegrationTest.java
+++ b/ai-hiring-backend/src/test/java/com/aihiring/matching/MatchControllerIntegrationTest.java
@@ -115,6 +115,37 @@ class MatchControllerIntegrationTest {
     }
 
     @Test
+    void match_overFetchesFromAiServiceToSurviveOrphanVectorFiltering() throws Exception {
+        // Regression for issue #147: orphan vectors (present in Qdrant but not in DB) can
+        // occupy top-K slots returned by the AI service, leaving zero results after orphan
+        // filtering. The backend must request more than top_k candidates from the AI
+        // service so orphan filtering still leaves room for live matches.
+        UUID jobId = UUID.randomUUID();
+        String aiResponseBody = """
+            {
+              "job_id": "%s",
+              "results": []
+            }
+            """.formatted(jobId);
+
+        wireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/match"))
+            .willReturn(WireMock.aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(aiResponseBody)));
+
+        mockMvc.perform(post("/api/match")
+                .with(adminUser())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"jobId\": \"%s\", \"topK\": 10}".formatted(jobId)))
+            .andExpect(status().isOk());
+
+        wireMock.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/match"))
+            .withRequestBody(WireMock.matchingJsonPath("$.top_k",
+                WireMock.matching("([3-9][0-9]|[1-9][0-9]{2,})"))));
+    }
+
+    @Test
     void match_whenAiServiceReturns404_propagates422() throws Exception {
         wireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/match"))
             .willReturn(WireMock.aResponse()


### PR DESCRIPTION
**Status**: READY FOR REVIEW

Fixes #147: Production AI Matching returns no candidates from Web UI despite processed resumes

**Issue**: https://github.com/yukunchen/aihiringsystem/issues/147

## Changes

- fix: over-fetch AI match candidates to survive orphan vector filtering

## Note

An independent Reviewer agent will post a structured review comment to this PR.
After merge, a separate Verifier agent will probe the live staging environment.
Neither agent can modify source files.

---
*Auto-generated by Claude Code Fixer agent in response to the `autofix` label.*

Closes #147
issue: #147