### PR TITLE
ci: auto-close stale deploy-failure issues on subsequent success

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -154,6 +154,32 @@ jobs:
           SHA: ${{ needs.verify.outputs.resolved_version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+      - name: Auto-close stale prod-failure issues
+        # A successful prod deploy (with health checks green) means the
+        # condition that the prior "Production deploy failed and rolled
+        # back" issues were recording is resolved. Close them with a
+        # reference back to this run.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ needs.verify.outputs.resolved_version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          STALE=$(gh issue list --repo "${{ github.repository }}" \
+              --state open --label deployment \
+              --search "Production deploy failed in:title" \
+              --json number --jq '.[].number' || echo "")
+          for N in $STALE; do
+            gh issue close "$N" --repo "${{ github.repository }}" \
+              --reason "not planned" \
+              --comment "Auto-closed: superseded by successful production deploy of \`${SHA:0:7}\`.
+
+            Prior failure was either a transient infra issue or has since been re-rolled forward. If a real problem remains, please reopen with reproduction steps.
+
+            Run: ${RUN_URL}" \
+              && echo "closed #$N" || echo "failed to close #$N"
+          done
+
   rollback:
     needs: [verify, deploy]
     if: failure()

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -308,6 +308,33 @@ jobs:
           DETAILS: ${{ steps.smoke.outputs.details }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+      - name: Auto-close stale staging-failure issues
+        # When staging goes green again, any previously auto-filed
+        # "Staging deploy failed at ..." issues are superseded. They are
+        # almost always transient infra flakes (GHCR 502, runner network
+        # blip). Leaving them open is pure noise. Close them with a
+        # reference to the succeeding run so the audit trail stays.
+        if: steps.smoke.outputs.pass == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          STALE=$(gh issue list --repo "${{ github.repository }}" \
+              --state open --label deployment \
+              --search "Staging deploy failed in:title" \
+              --json number --jq '.[].number' || echo "")
+          for N in $STALE; do
+            gh issue close "$N" --repo "${{ github.repository }}" \
+              --reason "not planned" \
+              --comment "Auto-closed: superseded by successful staging deploy of \`${SHA:0:7}\`.
+
+            The failure this issue recorded was a transient infrastructure flake that subsequent runs bypassed. If you were tracking a real recurring issue, please reopen with reproduction steps.
+
+            Run: ${RUN_URL}" \
+              && echo "closed #$N" || echo "failed to close #$N"
+          done
+
       - name: Fail the job if any smoke check failed
         # Placed AFTER the orchestrator-notify step so Discord still
         # receives the failure ping. Without this, smoke setting


### PR DESCRIPTION
## Motivation
Today's #151 and #152 are both transient GHCR 502 failures on \`build-and-push\`. The rerun succeeded, so the environment is green — but those two issues sit OPEN forever, accumulating noise. Same pattern applies to every future transient failure (network blip, runner hiccup, API rate limit).

Rule we want: **"deploy failed" issues are a live signal. Once that environment deploys successfully again, the signal is stale — auto-close it.**

## Changes
- \`deploy-staging.yml\` (after \`Notify orchestrator on VPS\`, only on \`steps.smoke.outputs.pass == 'true'\`):
  - \`gh issue list --label deployment --state open --search "Staging deploy failed in:title"\`
  - Close each with reason "not planned" and a comment linking back to the succeeding run.
- \`deploy-prod.yml\` (after \`Notify orchestrator (success)\`, only on \`success()\`):
  - Same sweep for "Production deploy failed" titles.

## Scope discussion
**Why not scope the close to same SHA?** Because reruns are common and the successful one usually uses a different commit (a later PR gets merged while the flake is still being debugged). Title-prefix match + \`label=deployment\` + \`state=open\` is a tight enough filter that false positives are essentially impossible — only the workflow itself files with that exact title prefix.

**False negatives?** If a failure is actually persistent (not a flake), the next deploy will fail too, won't reach this step, and will file a fresh issue. The "auto-close on success" can only run when the environment is healthy again, so it correctly avoids closing a still-broken state.

## Test plan
- [x] YAML lint on both workflows.
- [ ] Merge → staging auto-redeploys on master push → this step runs with \`pass=true\` → #151 and #152 close with the auto-comment.
- [ ] Negative: no open deployment issues → step finds empty list, no-ops cleanly.
- [ ] Negative: next real staging failure files a new issue as before; auto-close only runs on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)